### PR TITLE
added dotted underline to code links

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -183,6 +183,13 @@ strong {
   @apply font-mono;
 }
 
+a > code {
+  text-decoration-thickness: 1px;
+  text-decoration-line: underline;
+  text-decoration-skip-ink: 1px;
+  text-decoration-style: dashed;
+}
+
 pre.astro-code > code {
   all: unset;
 }


### PR DESCRIPTION
Before:

![image](https://github.com/scroll-tech/scroll-documentation/assets/4205837/07d333b1-62cd-46a2-8dc8-988defc073a3)

After:
![image](https://github.com/scroll-tech/scroll-documentation/assets/4205837/ce2cdbf1-03b5-4644-adac-eaa6108d9c30)
