### PR TITLE
fix excessive whitespace on short articles

### DIFF
--- a/src/components/PageContent/PageContent.astro
+++ b/src/components/PageContent/PageContent.astro
@@ -33,10 +33,6 @@ const whatsNext = content.whatsnext
     flex-direction: column;
   }
 
-  .content > section {
-    margin-bottom: 4rem;
-  }
-
   .block {
     display: block;
   }

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -88,7 +88,7 @@ changeLanguage(content.lang)
 
       .grid-sidebar {
         width: 100%;
-        height: 100vh;
+        max-height: 100vh;
         position: sticky;
         top: 0;
         padding: 0;


### PR DESCRIPTION
- Drop sidebar height of 100vh, changing to `max-height` to still support sticky sidebars.
- Drop article section bottom margin, since other elements already give plenty of whitespace here.