### PR TITLE
reduce inline code font weight

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -178,7 +178,6 @@ strong {
   border-radius: var(--border-radius);
   word-break: break-word;
   background: var(--gray-200);
-  font-weight: 500;
   color: var(--black-100);
   @apply font-mono;
 }


### PR DESCRIPTION
Polled DevRel on which was easier to read for technical content. Said lighter weight was prefered.

Before:
![image](https://github.com/scroll-tech/scroll-documentation/assets/4205837/f69112b9-4dba-468b-a660-c5581dea4932)
After:
![image](https://github.com/scroll-tech/scroll-documentation/assets/4205837/8786ff50-c9d7-4e3b-99cb-b16d71274274)

### Note:
I've removed `font-weight` so now code will inherit this attribute. This can seen in toggle areas and links.

Current:
![image](https://github.com/scroll-tech/scroll-documentation/assets/4205837/56aedb9e-d4b4-422f-ab3d-3406cf6a460b)

If we assign `font-weight: 400`:
![image](https://github.com/scroll-tech/scroll-documentation/assets/4205837/88ec3e54-a3e3-4aa4-996c-afb37adfbf21)

We might want to change this, but both are improving the current style.
