### PR TITLE
Update Scroll docs

### DIFF
--- a/src/content/docs/en/developers/l1-and-l2-bridging/erc721-nft-bridge.mdx
+++ b/src/content/docs/en/developers/l1-and-l2-bridging/erc721-nft-bridge.mdx
@@ -5,7 +5,7 @@ title: "ERC721 NFT Bridge"
 lang: "en"
 permalink: "developers/l1-and-l2-bridging/erc721-nft-bridge"
 excerpt: "NFT bridging from L1 to L2 is done via the L1ERC721Gateway contract instead of using a router."
-whatsnext: { "ERC1155 Token Bridge": "/developers/l1-and-l2-bridging/erc721-nft-bridge/" }
+whatsnext: { "ERC1155 Token Bridge": "/developers/l1-and-l2-bridging/erc1155-token-bridge/" }
 ---
 
 import Aside from "../../../../../components/Aside.astro"


### PR DESCRIPTION
when you're on **ERC721 NFT Bridge** page and scrolling down to whats next you see **ERC1155 Token Bridge** tap, when you click on it. it doesn't take you to **ERC1155 Token Bridge** page. it will reload the same page. so i fixed by editing the whats next line.

**IMPORTANT: Please do not create a Pull Request without creating an issue first.Any change needs to be discussed before proceeding.**

## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

closes #ISSUE_NUMBER_GOES_HERE

...

## Description

<!-- Please provide enough information so that others can review your pull request: -->

...

## Changes

<!--Explain the **details** for making this change. What existing problem does the pull request solve? -->

- High level
- changes that
- you made
- ...
