### PR TITLE
Removed trailing slashes in the URLs

### DIFF
--- a/src/content/docs/en/user-guide/faucet.mdx
+++ b/src/content/docs/en/user-guide/faucet.mdx
@@ -16,8 +16,8 @@ Each faucet has its own rules and requirements, so you may need to try a few bef
 
 Here are a few Sepolia faucet apps:
 
-- [https://sepoliafaucet.com](https://sepoliafaucet.com//)
-- [https://sepolia-faucet.pk910.de](https://sepolia-faucet.pk910.de/)
+- [https://sepoliafaucet.com](https://sepoliafaucet.com/)
+- [https://sepolia-faucet.pk910.de](https://sepolia-faucet.pk910.de)
 - [https://faucet.quicknode.com/drip](https://faucet.quicknode.com/drip)
 - [https://faucet.chainstack.com](https://faucet.chainstack.com)
 
@@ -32,6 +32,6 @@ Most faucets only allow requests for test tokens once every 24 hours.
 If you don't want to interact with the bridge, some faucets directly distribute Scroll Sepolia ETH. -->
 
 - [https://scroll.l2scan.co/faucet](https://scroll.l2scan.co/faucet)
-- [https://www.covalenthq.com/faucet/](https://www.covalenthq.com/faucet/)
+- [https://www.covalenthq.com/faucet/](https://www.covalenthq.com/faucet)
 - [https://faucet.quicknode.com/scroll/sepolia](https://faucet.quicknode.com/scroll/sepolia)
   {/* - [https://bwarelabs.com/faucets/scroll-testnet](https://bwarelabs.com/faucets/scroll-testnet) */}


### PR DESCRIPTION
One of them (sepoliafaucet,.com) was broken because of the double slash in the end

## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

closes #62 

## Changes

Removed trailing slashes from the urls
