### PR TITLE
feat: add technology/security section

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -129,7 +129,11 @@
       "bridgeOverview": "Bridge Overview",
       "prover": "Prover",
       "proofGeneration": "Proof Generation",
-      "cpuProverRepo": "CPU Prover Repo"
+      "cpuProverRepo": "CPU Prover Repo",
+
+      "security": "Security",
+      "auditsAndBugBounty": "Audits & Bug Bounty",
+      "l2BeatAssessment": "L2Beat Assessment"
     },
     "learn": {
       "ethereumAndProtocols": "Ethereum & Protocols",

--- a/src/config/sidebar.ts
+++ b/src/config/sidebar.ts
@@ -252,6 +252,23 @@ export const getSidebar = () => {
           },
         ],
       },
+      {
+        section: t("sidebar.technology.security"),
+        contents: [
+          {
+            title: t("sidebar.technology.auditsAndBugBounty"),
+            url: formatUrl("technology/security/audits-and-bug-bounty"),
+          },
+          // {
+          //   title: t("sidebar.technology.risks"),
+          //   url: formatUrl("technology/security/risks"),
+          // },
+          // {
+          //   title: t("sidebar.technology.l2BeatAssessment"),
+          //   url: "https://l2beat.com/scaling/projects/scroll",
+          // },
+        ],
+      },
     ],
     learn: [
       {

--- a/src/content/docs/en/technology/security/audits-and-bug-bounty.mdx
+++ b/src/content/docs/en/technology/security/audits-and-bug-bounty.mdx
@@ -74,4 +74,4 @@ Rewards depend on the severity of reported vulnerabilities:
 
 The scope of the bug bounty program covers the blockchain infrastructure and the smart contracts for bridging and rollup. For a detailed breakdown of bug categories, please refer to the bug bounty page.
 
-Besides the listed scopes in the bug bounty program, we also encourage reporting any vulnerabilities identified to Immunefi, which we will still consider for rewards. For any discoveries of critical vulnerabilities, please also send reports to security@scroll.io.
+Besides the listed scopes in the bug bounty program, we also encourage reporting any vulnerabilities identified to Immunefi, which we will still consider for rewards. For any discoveries of critical vulnerabilities outside of the scope of the bug bounty program, please also send reports to security@scroll.io.

--- a/src/content/docs/en/technology/security/audits-and-bug-bounty.mdx
+++ b/src/content/docs/en/technology/security/audits-and-bug-bounty.mdx
@@ -1,0 +1,75 @@
+---
+section: technology
+date: Last Modified
+title: "Audits & Bug Bounty Program"
+lang: "en"
+permalink: "technology/security/audits-and-bug-bounty"
+whatsnext: { "Risks": "/technology/security/risks/" }
+---
+
+import Aside from "../../../../../components/Aside.astro"
+
+Scroll treats security as a top priority.
+
+Aside from rigorous testing, an internal security team, and comprehensive code reviews, we have also engaged with multiple security audit firms to conduct audits on our codebase. We have also launched a bug bounty program to encourage the community to participate in the security of our protocol.
+
+<Aside type="danger" title="">
+  Audits don't guarantee the absence of security vulnerabilities. Using blockchains comes with risk, and Scroll is no
+  exception. We encourage users to use the protocol with caution and at their own risk.
+</Aside>
+
+## Independent Audits
+
+Scroll has worked with several industry-leading security audit firms to review our codebase, with critical code receiving reviews from multiple teams, including [Trail of Bits](https://www.trailofbits.com/), [Zellic](https://www.zellic.io/), [KALOS](https://www.kalos.xyz/), and [OpenZeppelin](https://www.openzeppelin.com/).
+
+- Trail of Bits, Zellic, and KALOS have reviewed our zkEVM circuits
+- OpenZeppelin and Zellic have performed independent audits on our bridge & rollup contracts
+- Trail of Bits has analyzed our node implementation
+
+<Aside type="tip" title="">
+  We're still working with partners to get all of our reports published. We'll update this page with links as they
+  become available.
+</Aside>
+
+### zkEVM circuits
+
+- Trail of Bits
+  - Wave 1 Report
+  - Wave 2 Report
+  - Wave 3 Report
+- Zellic and Kalos
+  - Wave 1 Report
+  - Wave 2 Report
+
+### Node implementation
+
+- Trail of Bits
+  - Wave 1 Report
+  - Wave 2 Report
+
+### Bridge and rollup contract
+
+- OpenZeppelin
+  - Report 1
+  - Report 2
+  - Report 3
+  - Report 4
+- Zellic
+  - Report 1
+  - Report 2
+
+## Bug Bounty Program
+
+Scroll has an active [Bug Bounty Program on Immunefi](https://immunefi.com/bounty/scroll/), a leading bug bounty platform. The program is open to the public, and we encourage anyone to participate.
+
+Rewards depend on the severity of reported vulnerabilities:
+
+- **Critical**: up to \$1,000,00
+- **High**: \$10,000 - \$50,000
+- **Medium**: \$5,000
+
+### Scope
+
+The scope of the bug bounty program covers the blockchain infrastructure and the smart contracts for bridging and rollup. For a detailed breakdown of bug categories, please refer to the bug bounty page.
+
+Besides the listed scopes in the bug bounty program, we also encourage security reviews on our [zkEVM circuits](https://github.com/scroll-tech/zkevm-circuits). For any discoveries, please kindly send your reports to security@scroll.io.

--- a/src/content/docs/en/technology/security/audits-and-bug-bounty.mdx
+++ b/src/content/docs/en/technology/security/audits-and-bug-bounty.mdx
@@ -4,7 +4,6 @@ date: Last Modified
 title: "Audits & Bug Bounty Program"
 lang: "en"
 permalink: "technology/security/audits-and-bug-bounty"
-whatsnext: { "Risks": "/technology/security/risks/" }
 ---
 
 import Aside from "../../../../../components/Aside.astro"
@@ -38,8 +37,8 @@ Scroll has worked with several industry-leading security audit firms to review o
   - Wave 2 Report
   - Wave 3 Report
 - Zellic and Kalos
-  - Wave 1 Report
-  - Wave 2 Report
+  - [Wave 1 Report](https://github.com/Zellic/publications/blob/master/Scroll%20zkEVM%20-%20Part%201%20Audit%20Report.pdf)
+  - [Wave 2 Report](https://github.com/Zellic/publications/blob/master/Scroll%20zkEVM%20-%20Part%202%20Audit%20Report.pdf)
 
 ### Node implementation
 
@@ -54,9 +53,11 @@ Scroll has worked with several industry-leading security audit firms to review o
   - Report 2
   - Report 3
   - Report 4
+  - Report 5
+  - Report 6
 - Zellic
-  - Report 1
-  - Report 2
+  - [Report 1](https://github.com/Zellic/publications/blob/master/Scroll%20-%2005.26.23%20Zellic%20Audit%20Report.pdf)
+  - [Report 2](https://github.com/Zellic/publications/blob/master/Scroll%20-%2009.27.23%20Zellic%20Audit%20Report.pdf)
 
 ## Bug Bounty Program
 

--- a/src/content/docs/en/technology/security/audits-and-bug-bounty.mdx
+++ b/src/content/docs/en/technology/security/audits-and-bug-bounty.mdx
@@ -20,7 +20,7 @@ Aside from rigorous testing, an internal security team, and comprehensive code r
 
 ## Independent Audits
 
-Scroll has worked with several industry-leading security audit firms to review our codebase, with critical code receiving reviews from multiple teams, including [Trail of Bits](https://www.trailofbits.com/), [Zellic](https://www.zellic.io/), [KALOS](https://www.kalos.xyz/), and [OpenZeppelin](https://www.openzeppelin.com/).
+Scroll has worked with several industry-leading security audit firms to review our codebase, with critical code receiving reviews from multiple teams, including [Trail of Bits](https://www.trailofbits.com/), [OpenZeppelin](https://www.openzeppelin.com/), [Zellic](https://www.zellic.io/), and [KALOS](https://www.kalos.xyz/).
 
 - Trail of Bits, Zellic, and KALOS have reviewed our zkEVM circuits
 - OpenZeppelin and Zellic have performed independent audits on our bridge & rollup contracts
@@ -72,4 +72,4 @@ Rewards depend on the severity of reported vulnerabilities:
 
 The scope of the bug bounty program covers the blockchain infrastructure and the smart contracts for bridging and rollup. For a detailed breakdown of bug categories, please refer to the bug bounty page.
 
-Besides the listed scopes in the bug bounty program, we also encourage security reviews on our [zkEVM circuits](https://github.com/scroll-tech/zkevm-circuits). For any discoveries, please kindly send your reports to security@scroll.io.
+Besides the listed scopes in the bug bounty program, we also encourage reporting any vulnerabilities identified to Immunefi, which we will still consider for rewards. For any discoveries of critical vulnerabilities, please also send reports to security@scroll.io.

--- a/src/content/docs/en/technology/security/audits-and-bug-bounty.mdx
+++ b/src/content/docs/en/technology/security/audits-and-bug-bounty.mdx
@@ -65,7 +65,7 @@ Scroll has an active [Bug Bounty Program on Immunefi](https://immunefi.com/bount
 
 Rewards depend on the severity of reported vulnerabilities:
 
-- **Critical**: up to \$1,000,00
+- **Critical**: up to \$1,000,000
 - **High**: \$10,000 - \$50,000
 - **Medium**: \$5,000
 

--- a/src/content/docs/en/technology/security/audits-and-bug-bounty.mdx
+++ b/src/content/docs/en/technology/security/audits-and-bug-bounty.mdx
@@ -33,28 +33,29 @@ Scroll has worked with several industry-leading security audit firms to review o
 ### zkEVM circuits
 
 - Trail of Bits
-  - Wave 1 Report
-  - Wave 2 Report
-  - Wave 3 Report
+  - Wave 1
+  - Wave 2
+  - Wave 3
 - Zellic and Kalos
-  - [Wave 1 Report](https://github.com/Zellic/publications/blob/master/Scroll%20zkEVM%20-%20Part%201%20Audit%20Report.pdf)
-  - [Wave 2 Report](https://github.com/Zellic/publications/blob/master/Scroll%20zkEVM%20-%20Part%202%20Audit%20Report.pdf)
+  - [Wave 1](https://github.com/Zellic/publications/blob/master/Scroll%20zkEVM%20-%20Part%201%20Audit%20Report.pdf)
+  - [Wave 2](https://github.com/Zellic/publications/blob/master/Scroll%20zkEVM%20-%20Part%202%20Audit%20Report.pdf)
 
 ### Node implementation
 
 - Trail of Bits
-  - Wave 1 Report
-  - Wave 2 Report
+  - [zkTrie](https://github.com/trailofbits/publications/blob/master/reviews/2023-07-scroll-zktrie-securityreview.pdf)
+  - L2geth
+  - [L2geth diff](https://github.com/trailofbits/publications/blob/master/reviews/2023-08-scrollL2geth-securityreview.pdf)
 
 ### Bridge and rollup contract
 
 - OpenZeppelin
-  - Report 1
-  - Report 2
-  - Report 3
-  - Report 4
-  - Report 5
-  - Report 6
+  - [Phase 1](https://blog.openzeppelin.com/scroll-layer-1-audit-1)
+  - [Phase 2](https://blog.openzeppelin.com/scroll-phase-2-audit)
+  - [GasSwap, Multiple Verifier, Wrapped Ether and Diff](https://blog.openzeppelin.com/scroll-gasswap-multiple-verifier-wrapped-ether-and-diff-audit)
+  - [ScrollOwner and Rate Limiter](https://blog.openzeppelin.com/scrollowner-and-rate-limiter-audit)
+  - [USDC Gateway](https://blog.openzeppelin.com/scroll-usdc-gateway-audit)
+  - [Contract diff](https://blog.openzeppelin.com/scroll-diff-audit-report)
 - Zellic
   - [Report 1](https://github.com/Zellic/publications/blob/master/Scroll%20-%2005.26.23%20Zellic%20Audit%20Report.pdf)
   - [Report 2](https://github.com/Zellic/publications/blob/master/Scroll%20-%2009.27.23%20Zellic%20Audit%20Report.pdf)


### PR DESCRIPTION
## Description

Adds a "Security" section, with information on our audits and upcoming bug bounty program.

Still needs URLs and a published Immunefi page.

Leaves places for a Risks page and an external link to L2Beat Assessment too, but we don't have those yet.
