### PR TITLE
chore: replace contract addresses with explorer URLs

### DIFF
--- a/src/content/docs/en/developers/scroll-contracts.mdx
+++ b/src/content/docs/en/developers/scroll-contracts.mdx
@@ -40,33 +40,33 @@ Use the table below to configure your Ethereum tools to the Scroll mainnet.
 
 ### Rollup
 
-- L1 Rollup (Scroll Chain): [`0xa13BAF47339d63B743e7Da8741db5456DAc1E556`](https://etherscan.com/address/0xa13BAF47339d63B743e7Da8741db5456DAc1E556)
+- L1 Rollup (Scroll Chain): [`0xa13BAF47339d63B743e7Da8741db5456DAc1E556`](https://etherscan.io/address/0xa13BAF47339d63B743e7Da8741db5456DAc1E556)
 
 ### ETH and ERC20 Bridge
 
-- L1 ERC20 Gateway Router: [`0xF8B1378579659D8F7EE5f3C929c2f3E332E41Fd6`](https://etherscan.com/address/0xF8B1378579659D8F7EE5f3C929c2f3E332E41Fd6)
+- L1 ERC20 Gateway Router: [`0xF8B1378579659D8F7EE5f3C929c2f3E332E41Fd6`](https://etherscan.io/address/0xF8B1378579659D8F7EE5f3C929c2f3E332E41Fd6)
 - L2 ERC20 Gateway Router: [`0x4C0926FF5252A435FD19e10ED15e5a249Ba19d79`](https://scrollscan.com/address/0x4C0926FF5252A435FD19e10ED15e5a249Ba19d79)
 
 ### Advanced Bridge Contracts
 
 - Scroll Messenger
-  - L1 Messenger: [`0x6774Bcbd5ceCeF1336b5300fb5186a12DDD8b367`](https://etherscan.com/address/0x6774Bcbd5ceCeF1336b5300fb5186a12DDD8b367)
+  - L1 Messenger: [`0x6774Bcbd5ceCeF1336b5300fb5186a12DDD8b367`](https://etherscan.io/address/0x6774Bcbd5ceCeF1336b5300fb5186a12DDD8b367)
   - L2 Messenger: [`0x781e90f1c8Fc4611c9b7497C3B47F99Ef6969CbC`](https://scrollscan.com/address/0x781e90f1c8Fc4611c9b7497C3B47F99Ef6969CbC)
 - ETH Bridge
-  - L1 ETH Gateway: [`0x7F2b8C31F88B6006c382775eea88297Ec1e3E905`](https://etherscan.com/address/0x7F2b8C31F88B6006c382775eea88297Ec1e3E905)
+  - L1 ETH Gateway: [`0x7F2b8C31F88B6006c382775eea88297Ec1e3E905`](https://etherscan.io/address/0x7F2b8C31F88B6006c382775eea88297Ec1e3E905)
   - L2 ETH Gateway: [`0x6EA73e05AdC79974B931123675ea8F78FfdacDF0`](https://scrollscan.com/address/0x6EA73e05AdC79974B931123675ea8F78FfdacDF0)
-  - L1 WETH Gateway: [`0x7AC440cAe8EB6328de4fA621163a792c1EA9D4fE`](https://etherscan.com/address/0x7AC440cAe8EB6328de4fA621163a792c1EA9D4fE)
+  - L1 WETH Gateway: [`0x7AC440cAe8EB6328de4fA621163a792c1EA9D4fE`](https://etherscan.io/address/0x7AC440cAe8EB6328de4fA621163a792c1EA9D4fE)
   - L2 WETH Gateway: [`0x7003E7B7186f0E6601203b99F7B8DECBfA391cf9`](https://scrollscan.com/address/0x7003E7B7186f0E6601203b99F7B8DECBfA391cf9)
 - ERC20 Bridge
-  - L1 ERC20 Standard Gateway: [`0xD8A791fE2bE73eb6E6cF1eb0cb3F36adC9B3F8f9`](https://etherscan.com/address/0xD8A791fE2bE73eb6E6cF1eb0cb3F36adC9B3F8f9)
+  - L1 ERC20 Standard Gateway: [`0xD8A791fE2bE73eb6E6cF1eb0cb3F36adC9B3F8f9`](https://etherscan.io/address/0xD8A791fE2bE73eb6E6cF1eb0cb3F36adC9B3F8f9)
   - L2 ERC20 Standard Gateway: [`0xE2b4795039517653c5Ae8C2A9BFdd783b48f447A`](https://scrollscan.com/address/0xE2b4795039517653c5Ae8C2A9BFdd783b48f447A)
-  - L1 ERC20 Custom Gateway: [`0xb2b10a289A229415a124EFDeF310C10cb004B6ff`](https://etherscan.com/address/0xb2b10a289A229415a124EFDeF310C10cb004B6ff)
+  - L1 ERC20 Custom Gateway: [`0xb2b10a289A229415a124EFDeF310C10cb004B6ff`](https://etherscan.io/address/0xb2b10a289A229415a124EFDeF310C10cb004B6ff)
   - L2 ERC20 Custom Gateway: [`0x64CCBE37c9A82D85A1F2E74649b7A42923067988`](https://scrollscan.com/address/0x64CCBE37c9A82D85A1F2E74649b7A42923067988)
 - ERC721 Bridge
-  - L1 ERC721 Gateway: [`0x6260aF48e8948617b8FA17F4e5CEa2d21D21554B`](https://etherscan.com/address/0x6260aF48e8948617b8FA17F4e5CEa2d21D21554B)
+  - L1 ERC721 Gateway: [`0x6260aF48e8948617b8FA17F4e5CEa2d21D21554B`](https://etherscan.io/address/0x6260aF48e8948617b8FA17F4e5CEa2d21D21554B)
   - L2 ERC721 Gateway: [`0x7bC08E1c04fb41d75F1410363F0c5746Eae80582`](https://scrollscan.com/address/0x7bC08E1c04fb41d75F1410363F0c5746Eae80582)
 - ERC1155 Bridge
-  - L1 ERC1155 Gateway: [`0xb94f7F6ABcb811c5Ac709dE14E37590fcCd975B6`](https://etherscan.com/address/0xb94f7F6ABcb811c5Ac709dE14E37590fcCd975B6)
+  - L1 ERC1155 Gateway: [`0xb94f7F6ABcb811c5Ac709dE14E37590fcCd975B6`](https://etherscan.io/address/0xb94f7F6ABcb811c5Ac709dE14E37590fcCd975B6)
   - L2 ERC1155 Gateway: [`0x62597Cc19703aF10B58feF87B0d5D29eFE263bcc`](https://scrollscan.com/address/0x62597Cc19703aF10B58feF87B0d5D29eFE263bcc)
 - Gas Oracle
   - L2 Gas Oracle (deployed on Mainnet): [`0x987e300fDfb06093859358522a79098848C33852`](https://scrollscan.com/address/0x987e300fDfb06093859358522a79098848C33852)
@@ -144,33 +144,33 @@ Use the table below to configure your Ethereum tools to the Scroll Sepolia Testn
 
 #### Rollup
 
-- L1 Rollup (Scroll Chain): [`0x2D567EcE699Eabe5afCd141eDB7A4f2D0D6ce8a0`](https://sepolia.etherscan.com/address/0x2D567EcE699Eabe5afCd141eDB7A4f2D0D6ce8a0)
+- L1 Rollup (Scroll Chain): [`0x2D567EcE699Eabe5afCd141eDB7A4f2D0D6ce8a0`](https://sepolia.etherscan.io/address/0x2D567EcE699Eabe5afCd141eDB7A4f2D0D6ce8a0)
 
 #### ETH and ERC20 Bridge
 
-- L1 ERC20 Gateway Router: [`0x13FBE0D0e5552b8c9c4AE9e2435F38f37355998a`](https://sepolia.etherscan.com/address/0x13FBE0D0e5552b8c9c4AE9e2435F38f37355998a)
+- L1 ERC20 Gateway Router: [`0x13FBE0D0e5552b8c9c4AE9e2435F38f37355998a`](https://sepolia.etherscan.io/address/0x13FBE0D0e5552b8c9c4AE9e2435F38f37355998a)
 - L2 ERC20 Gateway Router: [`0x9aD3c5617eCAa556d6E166787A97081907171230`](https://sepolia.scrollscan.com/address/0x9aD3c5617eCAa556d6E166787A97081907171230)
 
 #### Advanced Bridge Contracts
 
 - Scroll Messenger
-  - L1 Messenger: [`0x50c7d3e7f7c656493D1D76aaa1a836CedfCBB16A`](https://sepolia.etherscan.com/address/0x50c7d3e7f7c656493D1D76aaa1a836CedfCBB16A)
+  - L1 Messenger: [`0x50c7d3e7f7c656493D1D76aaa1a836CedfCBB16A`](https://sepolia.etherscan.io/address/0x50c7d3e7f7c656493D1D76aaa1a836CedfCBB16A)
   - L2 Messenger: [`0xBa50f5340FB9F3Bd074bD638c9BE13eCB36E603d`](https://sepolia.scrollscan.com/address/0xBa50f5340FB9F3Bd074bD638c9BE13eCB36E603d)
 - ETH Bridge
-  - L1 ETH Gateway: [`0x8A54A2347Da2562917304141ab67324615e9866d`](https://sepolia.etherscan.com/address/0x8A54A2347Da2562917304141ab67324615e9866d)
+  - L1 ETH Gateway: [`0x8A54A2347Da2562917304141ab67324615e9866d`](https://sepolia.etherscan.io/address/0x8A54A2347Da2562917304141ab67324615e9866d)
   - L2 ETH Gateway: [`0x91e8ADDFe1358aCa5314c644312d38237fC1101C`](https://sepolia.scrollscan.com/address/0x91e8ADDFe1358aCa5314c644312d38237fC1101C)
-  - L1 WETH Gateway: [`0x3dA0BF44814cfC678376b3311838272158211695`](https://sepolia.etherscan.com/address/0x3dA0BF44814cfC678376b3311838272158211695)
+  - L1 WETH Gateway: [`0x3dA0BF44814cfC678376b3311838272158211695`](https://sepolia.etherscan.io/address/0x3dA0BF44814cfC678376b3311838272158211695)
   - L2 WETH Gateway: [`0x481B20A927206aF7A754dB8b904B052e2781ea27`](https://sepolia.scrollscan.com/address/0x481B20A927206aF7A754dB8b904B052e2781ea27)
 - ERC20 Bridge
-  - L1 ERC20 Standard Gateway: [`0x65D123d6389b900d954677c26327bfc1C3e88A13`](https://sepolia.etherscan.com/address/0x65D123d6389b900d954677c26327bfc1C3e88A13)
+  - L1 ERC20 Standard Gateway: [`0x65D123d6389b900d954677c26327bfc1C3e88A13`](https://sepolia.etherscan.io/address/0x65D123d6389b900d954677c26327bfc1C3e88A13)
   - L2 ERC20 Standard Gateway: [`0xaDcA915971A336EA2f5b567e662F5bd74AEf9582`](https://sepolia.scrollscan.com/address/0xaDcA915971A336EA2f5b567e662F5bd74AEf9582)
-  - L1 ERC20 Custom Gateway: [`0x31C994F2017E71b82fd4D8118F140c81215bbb37`](https://sepolia.etherscan.com/address/0x31C994F2017E71b82fd4D8118F140c81215bbb37)
+  - L1 ERC20 Custom Gateway: [`0x31C994F2017E71b82fd4D8118F140c81215bbb37`](https://sepolia.etherscan.io/address/0x31C994F2017E71b82fd4D8118F140c81215bbb37)
   - L2 ERC20 Custom Gateway: [`0x058dec71E53079F9ED053F3a0bBca877F6f3eAcf`](https://sepolia.scrollscan.com/address/0x058dec71E53079F9ED053F3a0bBca877F6f3eAcf)
 - ERC721 Bridge
-  - L1 ERC721 Gateway: [`0xEF27A5E63aa3f1B8312f744b9b4DcEB910Ba77AC`](https://sepolia.etherscan.com/address/0xEF27A5E63aa3f1B8312f744b9b4DcEB910Ba77AC)
+  - L1 ERC721 Gateway: [`0xEF27A5E63aa3f1B8312f744b9b4DcEB910Ba77AC`](https://sepolia.etherscan.io/address/0xEF27A5E63aa3f1B8312f744b9b4DcEB910Ba77AC)
   - L2 ERC721 Gateway: [`0x179B9415194B67DC3c0b8760E075cD4415785c97`](https://sepolia.scrollscan.com/address/0x179B9415194B67DC3c0b8760E075cD4415785c97)
 - ERC1155 Bridge
-  - L1 ERC1155 Gateway: [`0xa5Df8530766A85936EE3E139dECE3bF081c83146`](https://sepolia.etherscan.com/address/0xa5Df8530766A85936EE3E139dECE3bF081c83146)
+  - L1 ERC1155 Gateway: [`0xa5Df8530766A85936EE3E139dECE3bF081c83146`](https://sepolia.etherscan.io/address/0xa5Df8530766A85936EE3E139dECE3bF081c83146)
   - L2 ERC1155 Gateway: [`0xe17C9b9C66FAF07753cdB04316D09f52144612A5`](https://sepolia.scrollscan.com/address/0xe17C9b9C66FAF07753cdB04316D09f52144612A5)
 - Gas Oracle
   - L2 Gas Oracle (deployed on Sepolia): [`0x247969F4fad93a33d4826046bc3eAE0D36BdE548`](https://sepolia.scrollscan.com/address/0x247969F4fad93a33d4826046bc3eAE0D36BdE548)

--- a/src/content/docs/en/developers/scroll-contracts.mdx
+++ b/src/content/docs/en/developers/scroll-contracts.mdx
@@ -40,67 +40,67 @@ Use the table below to configure your Ethereum tools to the Scroll mainnet.
 
 ### Rollup
 
-- L1 Rollup (Scroll Chain): `0xa13BAF47339d63B743e7Da8741db5456DAc1E556`
+- L1 Rollup (Scroll Chain): [`0xa13BAF47339d63B743e7Da8741db5456DAc1E556`](https://etherscan.com/address/0xa13BAF47339d63B743e7Da8741db5456DAc1E556)
 
 ### ETH and ERC20 Bridge
 
-- L1 ERC20 Gateway Router: `0xF8B1378579659D8F7EE5f3C929c2f3E332E41Fd6`
-- L2 ERC20 Gateway Router: `0x4C0926FF5252A435FD19e10ED15e5a249Ba19d79`
+- L1 ERC20 Gateway Router: [`0xF8B1378579659D8F7EE5f3C929c2f3E332E41Fd6`](https://etherscan.com/address/0xF8B1378579659D8F7EE5f3C929c2f3E332E41Fd6)
+- L2 ERC20 Gateway Router: [`0x4C0926FF5252A435FD19e10ED15e5a249Ba19d79`](https://scrollscan.com/address/0x4C0926FF5252A435FD19e10ED15e5a249Ba19d79)
 
 ### Advanced Bridge Contracts
 
 - Scroll Messenger
-  - L1 Messenger: `0x6774Bcbd5ceCeF1336b5300fb5186a12DDD8b367`
-  - L2 Messenger: `0x781e90f1c8Fc4611c9b7497C3B47F99Ef6969CbC`
+  - L1 Messenger: [`0x6774Bcbd5ceCeF1336b5300fb5186a12DDD8b367`](https://etherscan.com/address/0x6774Bcbd5ceCeF1336b5300fb5186a12DDD8b367)
+  - L2 Messenger: [`0x781e90f1c8Fc4611c9b7497C3B47F99Ef6969CbC`](https://scrollscan.com/address/0x781e90f1c8Fc4611c9b7497C3B47F99Ef6969CbC)
 - ETH Bridge
-  - L1 ETH Gateway: `0x7F2b8C31F88B6006c382775eea88297Ec1e3E905`
-  - L2 ETH Gateway: `0x6EA73e05AdC79974B931123675ea8F78FfdacDF0`
-  - L1 WETH Gateway: `0x7AC440cAe8EB6328de4fA621163a792c1EA9D4fE`
-  - L2 WETH Gateway: `0x7003E7B7186f0E6601203b99F7B8DECBfA391cf9`
+  - L1 ETH Gateway: [`0x7F2b8C31F88B6006c382775eea88297Ec1e3E905`](https://etherscan.com/address/0x7F2b8C31F88B6006c382775eea88297Ec1e3E905)
+  - L2 ETH Gateway: [`0x6EA73e05AdC79974B931123675ea8F78FfdacDF0`](https://scrollscan.com/address/0x6EA73e05AdC79974B931123675ea8F78FfdacDF0)
+  - L1 WETH Gateway: [`0x7AC440cAe8EB6328de4fA621163a792c1EA9D4fE`](https://etherscan.com/address/0x7AC440cAe8EB6328de4fA621163a792c1EA9D4fE)
+  - L2 WETH Gateway: [`0x7003E7B7186f0E6601203b99F7B8DECBfA391cf9`](https://scrollscan.com/address/0x7003E7B7186f0E6601203b99F7B8DECBfA391cf9)
 - ERC20 Bridge
-  - L1 ERC20 Standard Gateway: `0xD8A791fE2bE73eb6E6cF1eb0cb3F36adC9B3F8f9`
-  - L2 ERC20 Standard Gateway: `0xE2b4795039517653c5Ae8C2A9BFdd783b48f447A`
-  - L1 ERC20 Custom Gateway: `0xb2b10a289A229415a124EFDeF310C10cb004B6ff`
-  - L2 ERC20 Custom Gateway: `0x64CCBE37c9A82D85A1F2E74649b7A42923067988`
+  - L1 ERC20 Standard Gateway: [`0xD8A791fE2bE73eb6E6cF1eb0cb3F36adC9B3F8f9`](https://etherscan.com/address/0xD8A791fE2bE73eb6E6cF1eb0cb3F36adC9B3F8f9)
+  - L2 ERC20 Standard Gateway: [`0xE2b4795039517653c5Ae8C2A9BFdd783b48f447A`](https://scrollscan.com/address/0xE2b4795039517653c5Ae8C2A9BFdd783b48f447A)
+  - L1 ERC20 Custom Gateway: [`0xb2b10a289A229415a124EFDeF310C10cb004B6ff`](https://etherscan.com/address/0xb2b10a289A229415a124EFDeF310C10cb004B6ff)
+  - L2 ERC20 Custom Gateway: [`0x64CCBE37c9A82D85A1F2E74649b7A42923067988`](https://scrollscan.com/address/0x64CCBE37c9A82D85A1F2E74649b7A42923067988)
 - ERC721 Bridge
-  - L1 ERC721 Gateway: `0x6260aF48e8948617b8FA17F4e5CEa2d21D21554B`
-  - L2 ERC721 Gateway: `0x7bC08E1c04fb41d75F1410363F0c5746Eae80582`
+  - L1 ERC721 Gateway: [`0x6260aF48e8948617b8FA17F4e5CEa2d21D21554B`](https://etherscan.com/address/0x6260aF48e8948617b8FA17F4e5CEa2d21D21554B)
+  - L2 ERC721 Gateway: [`0x7bC08E1c04fb41d75F1410363F0c5746Eae80582`](https://scrollscan.com/address/0x7bC08E1c04fb41d75F1410363F0c5746Eae80582)
 - ERC1155 Bridge
-  - L1 ERC1155 Gateway: `0xb94f7F6ABcb811c5Ac709dE14E37590fcCd975B6`
-  - L2 ERC1155 Gateway: `0x62597Cc19703aF10B58feF87B0d5D29eFE263bcc`
+  - L1 ERC1155 Gateway: [`0xb94f7F6ABcb811c5Ac709dE14E37590fcCd975B6`](https://etherscan.com/address/0xb94f7F6ABcb811c5Ac709dE14E37590fcCd975B6)
+  - L2 ERC1155 Gateway: [`0x62597Cc19703aF10B58feF87B0d5D29eFE263bcc`](https://scrollscan.com/address/0x62597Cc19703aF10B58feF87B0d5D29eFE263bcc)
 - Gas Oracle
-  - L2 Gas Oracle (deployed on Mainnet): `0x987e300fDfb06093859358522a79098848C33852`
+  - L2 Gas Oracle (deployed on Mainnet): [`0x987e300fDfb06093859358522a79098848C33852`](https://scrollscan.com/address/0x987e300fDfb06093859358522a79098848C33852)
 
 ### L2 Predeploys
 
-- Message Queue: `0x5300000000000000000000000000000000000000`
-- Gas Price Oracle: `0x5300000000000000000000000000000000000002`
-- Whitelist: `0x5300000000000000000000000000000000000003`
-- WETH L2: `0x5300000000000000000000000000000000000004`
-- Transaction Fee Vault: `0x5300000000000000000000000000000000000005`
+- Message Queue: [`0x5300000000000000000000000000000000000000`](https://scrollscan.com/address/0x5300000000000000000000000000000000000000)
+- Gas Price Oracle: [`0x5300000000000000000000000000000000000002`](https://scrollscan.com/address/0x5300000000000000000000000000000000000002)
+- Whitelist: [`0x5300000000000000000000000000000000000003`](https://scrollscan.com/address/0x5300000000000000000000000000000000000003)
+- WETH L2: [`0x5300000000000000000000000000000000000004`](https://scrollscan.com/address/0x5300000000000000000000000000000000000004)
+- Transaction Fee Vault: [`0x5300000000000000000000000000000000000005`](https://scrollscan.com/address/0x5300000000000000000000000000000000000005)
 
 ## Protocols on Scroll Mainnet
 
 ### Uniswap v3
 
 - Main Contracts
-  - Core Factory: `0x70C62C8b8e801124A4Aa81ce07b637A3e83cb919`
-  - NFT Position Manager: `0xB39002E4033b162fAc607fc3471E205FA2aE5967`
-  - Router: `0xfc30937f5cDe93Df8d48aCAF7e6f5D8D8A31F636`
+  - Core Factory: [`0x70C62C8b8e801124A4Aa81ce07b637A3e83cb919`](https://scrollscan.com/address/0x70C62C8b8e801124A4Aa81ce07b637A3e83cb919)
+  - NFT Position Manager: [`0xB39002E4033b162fAc607fc3471E205FA2aE5967`](https://scrollscan.com/address/0xB39002E4033b162fAc607fc3471E205FA2aE5967)
+  - Router: [`0xfc30937f5cDe93Df8d48aCAF7e6f5D8D8A31F636`](https://scrollscan.com/address/0xfc30937f5cDe93Df8d48aCAF7e6f5D8D8A31F636)
 - Additional Contracts
-  - multicall2Address: `0xC1D2e074C38FdD5CA965000668420C80316F0915`
-  - proxyAdminAddress: `0x1E6dcAb806A42055098f23E2B3ac72D6E195F967`
-  - tickLensAddress: `0x85780e12e90D2a684eB8E7404c985b5B5c8ce7E9`
-  - nftDescriptorLibraryAddressV1_3_0: `0xAeE9c206ba89F3DA25EEe4636208519e0B86965B`
-  - nonfungibleTokenPositionDescriptorAddressV1_3_0: `0xACcf12204b7591B2ECCEFe737440B0f53748B191`
-  - descriptorProxyAddress: `0x675DD953225D296A44790dC1390a1E7eF378f464`
-  - v3MigratorAddress: `0xF00577B5Dd0DA227298E954Ed11356F264Cf93d4`
-  - v3StakerAddress: `0xFdFbE973c9ecB036Ecfb7af697FcACe789D3f928`
-  - quoterV2Address: `0x2566e082Cb1656d22BCbe5644F5b997D194b5299`
+  - multicall2Address: [`0xC1D2e074C38FdD5CA965000668420C80316F0915`](https://scrollscan.com/address/0xC1D2e074C38FdD5CA965000668420C80316F0915)
+  - proxyAdminAddress: [`0x1E6dcAb806A42055098f23E2B3ac72D6E195F967`](https://scrollscan.com/address/0x1E6dcAb806A42055098f23E2B3ac72D6E195F967)
+  - tickLensAddress: [`0x85780e12e90D2a684eB8E7404c985b5B5c8ce7E9`](https://scrollscan.com/address/0x85780e12e90D2a684eB8E7404c985b5B5c8ce7E9)
+  - nftDescriptorLibraryAddressV1_3_0: [`0xAeE9c206ba89F3DA25EEe4636208519e0B86965B`](https://scrollscan.com/address/0xAeE9c206ba89F3DA25EEe4636208519e0B86965B)
+  - nonfungibleTokenPositionDescriptorAddressV1_3_0: [`0xACcf12204b7591B2ECCEFe737440B0f53748B191`](https://scrollscan.com/address/0xACcf12204b7591B2ECCEFe737440B0f53748B191)
+  - descriptorProxyAddress: [`0x675DD953225D296A44790dC1390a1E7eF378f464`](https://scrollscan.com/address/0x675DD953225D296A44790dC1390a1E7eF378f464)
+  - v3MigratorAddress: [`0xF00577B5Dd0DA227298E954Ed11356F264Cf93d4`](https://scrollscan.com/address/0xF00577B5Dd0DA227298E954Ed11356F264Cf93d4)
+  - v3StakerAddress: [`0xFdFbE973c9ecB036Ecfb7af697FcACe789D3f928`](https://scrollscan.com/address/0xFdFbE973c9ecB036Ecfb7af697FcACe789D3f928)
+  - quoterV2Address: [`0x2566e082Cb1656d22BCbe5644F5b997D194b5299`](https://scrollscan.com/address/0x2566e082Cb1656d22BCbe5644F5b997D194b5299)
 
 ## Additional Useful Contracts
 
-- Multicall3: `0xcA11bde05977b3631167028862bE2a173976CA11`
+- Multicall3: [`0xcA11bde05977b3631167028862bE2a173976CA11`](https://scrollscan.com/address/0xcA11bde05977b3631167028862bE2a173976CA11)
 
 ## Tokens
 
@@ -144,44 +144,44 @@ Use the table below to configure your Ethereum tools to the Scroll Sepolia Testn
 
 #### Rollup
 
-- L1 Rollup (Scroll Chain): `0x2D567EcE699Eabe5afCd141eDB7A4f2D0D6ce8a0`
+- L1 Rollup (Scroll Chain): [`0x2D567EcE699Eabe5afCd141eDB7A4f2D0D6ce8a0`](https://sepolia.etherscan.com/address/0x2D567EcE699Eabe5afCd141eDB7A4f2D0D6ce8a0)
 
 #### ETH and ERC20 Bridge
 
-- L1 ERC20 Gateway Router: `0x13FBE0D0e5552b8c9c4AE9e2435F38f37355998a`
-- L2 ERC20 Gateway Router: `0x9aD3c5617eCAa556d6E166787A97081907171230`
+- L1 ERC20 Gateway Router: [`0x13FBE0D0e5552b8c9c4AE9e2435F38f37355998a`](https://sepolia.etherscan.com/address/0x13FBE0D0e5552b8c9c4AE9e2435F38f37355998a)
+- L2 ERC20 Gateway Router: [`0x9aD3c5617eCAa556d6E166787A97081907171230`](https://sepolia.scrollscan.com/address/0x9aD3c5617eCAa556d6E166787A97081907171230)
 
 #### Advanced Bridge Contracts
 
 - Scroll Messenger
-  - L1 Messenger: `0x50c7d3e7f7c656493D1D76aaa1a836CedfCBB16A`
-  - L2 Messenger: `0xBa50f5340FB9F3Bd074bD638c9BE13eCB36E603d`
+  - L1 Messenger: [`0x50c7d3e7f7c656493D1D76aaa1a836CedfCBB16A`](https://sepolia.etherscan.com/address/0x50c7d3e7f7c656493D1D76aaa1a836CedfCBB16A)
+  - L2 Messenger: [`0xBa50f5340FB9F3Bd074bD638c9BE13eCB36E603d`](https://sepolia.scrollscan.com/address/0xBa50f5340FB9F3Bd074bD638c9BE13eCB36E603d)
 - ETH Bridge
-  - L1 ETH Gateway: `0x8A54A2347Da2562917304141ab67324615e9866d`
-  - L2 ETH Gateway: `0x91e8ADDFe1358aCa5314c644312d38237fC1101C`
-  - L1 WETH Gateway: `0x3dA0BF44814cfC678376b3311838272158211695`
-  - L2 WETH Gateway: `0x481B20A927206aF7A754dB8b904B052e2781ea27`
+  - L1 ETH Gateway: [`0x8A54A2347Da2562917304141ab67324615e9866d`](https://sepolia.etherscan.com/address/0x8A54A2347Da2562917304141ab67324615e9866d)
+  - L2 ETH Gateway: [`0x91e8ADDFe1358aCa5314c644312d38237fC1101C`](https://sepolia.scrollscan.com/address/0x91e8ADDFe1358aCa5314c644312d38237fC1101C)
+  - L1 WETH Gateway: [`0x3dA0BF44814cfC678376b3311838272158211695`](https://sepolia.etherscan.com/address/0x3dA0BF44814cfC678376b3311838272158211695)
+  - L2 WETH Gateway: [`0x481B20A927206aF7A754dB8b904B052e2781ea27`](https://sepolia.scrollscan.com/address/0x481B20A927206aF7A754dB8b904B052e2781ea27)
 - ERC20 Bridge
-  - L1 ERC20 Standard Gateway: `0x65D123d6389b900d954677c26327bfc1C3e88A13`
-  - L2 ERC20 Standard Gateway: `0xaDcA915971A336EA2f5b567e662F5bd74AEf9582`
-  - L1 ERC20 Custom Gateway: `0x31C994F2017E71b82fd4D8118F140c81215bbb37`
-  - L2 ERC20 Custom Gateway: `0x058dec71E53079F9ED053F3a0bBca877F6f3eAcf`
+  - L1 ERC20 Standard Gateway: [`0x65D123d6389b900d954677c26327bfc1C3e88A13`](https://sepolia.etherscan.com/address/0x65D123d6389b900d954677c26327bfc1C3e88A13)
+  - L2 ERC20 Standard Gateway: [`0xaDcA915971A336EA2f5b567e662F5bd74AEf9582`](https://sepolia.scrollscan.com/address/0xaDcA915971A336EA2f5b567e662F5bd74AEf9582)
+  - L1 ERC20 Custom Gateway: [`0x31C994F2017E71b82fd4D8118F140c81215bbb37`](https://sepolia.etherscan.com/address/0x31C994F2017E71b82fd4D8118F140c81215bbb37)
+  - L2 ERC20 Custom Gateway: [`0x058dec71E53079F9ED053F3a0bBca877F6f3eAcf`](https://sepolia.scrollscan.com/address/0x058dec71E53079F9ED053F3a0bBca877F6f3eAcf)
 - ERC721 Bridge
-  - L1 ERC721 Gateway: `0xEF27A5E63aa3f1B8312f744b9b4DcEB910Ba77AC`
-  - L2 ERC721 Gateway: `0x179B9415194B67DC3c0b8760E075cD4415785c97`
+  - L1 ERC721 Gateway: [`0xEF27A5E63aa3f1B8312f744b9b4DcEB910Ba77AC`](https://sepolia.etherscan.com/address/0xEF27A5E63aa3f1B8312f744b9b4DcEB910Ba77AC)
+  - L2 ERC721 Gateway: [`0x179B9415194B67DC3c0b8760E075cD4415785c97`](https://sepolia.scrollscan.com/address/0x179B9415194B67DC3c0b8760E075cD4415785c97)
 - ERC1155 Bridge
-  - L1 ERC1155 Gateway: `0xa5Df8530766A85936EE3E139dECE3bF081c83146`
-  - L2 ERC1155 Gateway: `0xe17C9b9C66FAF07753cdB04316D09f52144612A5`
+  - L1 ERC1155 Gateway: [`0xa5Df8530766A85936EE3E139dECE3bF081c83146`](https://sepolia.etherscan.com/address/0xa5Df8530766A85936EE3E139dECE3bF081c83146)
+  - L2 ERC1155 Gateway: [`0xe17C9b9C66FAF07753cdB04316D09f52144612A5`](https://sepolia.scrollscan.com/address/0xe17C9b9C66FAF07753cdB04316D09f52144612A5)
 - Gas Oracle
-  - L2 Gas Oracle (deployed on Sepolia): `0x247969F4fad93a33d4826046bc3eAE0D36BdE548`
+  - L2 Gas Oracle (deployed on Sepolia): [`0x247969F4fad93a33d4826046bc3eAE0D36BdE548`](https://sepolia.scrollscan.com/address/0x247969F4fad93a33d4826046bc3eAE0D36BdE548)
 
 #### L2 Predeploys
 
-- Message Queue: `0x5300000000000000000000000000000000000000`
-- Gas Price Oracle: `0x5300000000000000000000000000000000000002`
-- Whitelist: `0x5300000000000000000000000000000000000003`
-- WETH L2: `0x5300000000000000000000000000000000000004`
-- Transaction Fee Vault: `0x5300000000000000000000000000000000000005`
+- Message Queue: [`0x5300000000000000000000000000000000000000`](https://sepolia.scrollscan.com/address/0x5300000000000000000000000000000000000000)
+- Gas Price Oracle: [`0x5300000000000000000000000000000000000002`](https://sepolia.scrollscan.com/address/0x5300000000000000000000000000000000000002)
+- Whitelist: [`0x5300000000000000000000000000000000000003`](https://sepolia.scrollscan.com/address/0x5300000000000000000000000000000000000003)
+- WETH L2: [`0x5300000000000000000000000000000000000004`](https://sepolia.scrollscan.com/address/0x5300000000000000000000000000000000000004)
+- Transaction Fee Vault: [`0x5300000000000000000000000000000000000005`](https://sepolia.scrollscan.com/address/0x5300000000000000000000000000000000000005)
 
 ### Protocols
 
@@ -189,19 +189,19 @@ Use the table below to configure your Ethereum tools to the Scroll Sepolia Testn
 
 - Frontend website: [https://uniswap-showcase.sepolia.scroll.xyz/](https://uniswap-showcase.sepolia.scroll.xyz/)
 - Main Contracts
-  - Core Factory: `0xB856587fe1cbA8600F75F1b1176E44250B11C788`
-  - NFT Position Manager: `0xbbAd0e891922A8A4a7e9c39d4cc0559117016fec`
-  - Router: `0x17AFD0263D6909Ba1F9a8EAC697f76532365Fb95`
+  - Core Factory: [`0xB856587fe1cbA8600F75F1b1176E44250B11C788`](https://sepolia.scrollscan.com/address/0xB856587fe1cbA8600F75F1b1176E44250B11C788)
+  - NFT Position Manager: [`0xbbAd0e891922A8A4a7e9c39d4cc0559117016fec`](https://sepolia.scrollscan.com/address/0xbbAd0e891922A8A4a7e9c39d4cc0559117016fec)
+  - Router: [`0x17AFD0263D6909Ba1F9a8EAC697f76532365Fb95`](https://sepolia.scrollscan.com/address/0x17AFD0263D6909Ba1F9a8EAC697f76532365Fb95)
 - Additional Contracts
-  - multicall2Address: `0x8c181f4B9040F1a2C941EfD3b608712cF86F1957`
-  - proxyAdminAddress: `0xD4A9910732b6f301F6F210Ebe7a3dBf16d9E9DD4`
-  - tickLensAddress: `0x9804Da978427a49929f2E6Ea32A9594F03f9296e`
-  - nftDescriptorLibraryAddressV1_3_0: `0x45Bd3B62B7A3aA53371c98049b0f7A9C1A4B5a6c`
-  - nonfungibleTokenPositionDescriptorAddressV1_3_0: `0x24d4E4a572Dc1e0dbF92a0d7768Ac80df516b2C2`
-  - descriptorProxyAddress: `0xa8986417d0EAe50607696b9b0cb7ec5aFBE67765`
-  - v3MigratorAddress: `0x38E33D067F03a5cDc02C301b2c306cb0414549Bf`
-  - v3StakerAddress: `0xe7b82794Cab21e665a3e6f8ea562d392AA6E0619`
-  - quoterV2Address: `0xd5dd33650Ef1DC6D23069aEDC8EAE87b0D3619B2`
+  - multicall2Address: [`0x8c181f4B9040F1a2C941EfD3b608712cF86F1957`](https://sepolia.scrollscan.com/address/0x8c181f4B9040F1a2C941EfD3b608712cF86F1957)
+  - proxyAdminAddress: [`0xD4A9910732b6f301F6F210Ebe7a3dBf16d9E9DD4`](https://sepolia.scrollscan.com/address/0xD4A9910732b6f301F6F210Ebe7a3dBf16d9E9DD4)
+  - tickLensAddress: [`0x9804Da978427a49929f2E6Ea32A9594F03f9296e`](https://sepolia.scrollscan.com/address/0x9804Da978427a49929f2E6Ea32A9594F03f9296e)
+  - nftDescriptorLibraryAddressV1_3_0: [`0x45Bd3B62B7A3aA53371c98049b0f7A9C1A4B5a6c`](https://sepolia.scrollscan.com/address/0x45Bd3B62B7A3aA53371c98049b0f7A9C1A4B5a6c)
+  - nonfungibleTokenPositionDescriptorAddressV1_3_0: [`0x24d4E4a572Dc1e0dbF92a0d7768Ac80df516b2C2`](https://sepolia.scrollscan.com/address/0x24d4E4a572Dc1e0dbF92a0d7768Ac80df516b2C2)
+  - descriptorProxyAddress: [`0xa8986417d0EAe50607696b9b0cb7ec5aFBE67765`](https://sepolia.scrollscan.com/address/0xa8986417d0EAe50607696b9b0cb7ec5aFBE67765)
+  - v3MigratorAddress: [`0x38E33D067F03a5cDc02C301b2c306cb0414549Bf`](https://sepolia.scrollscan.com/address/0x38E33D067F03a5cDc02C301b2c306cb0414549Bf)
+  - v3StakerAddress: [`0xe7b82794Cab21e665a3e6f8ea562d392AA6E0619`](https://sepolia.scrollscan.com/address/0xe7b82794Cab21e665a3e6f8ea562d392AA6E0619)
+  - quoterV2Address: [`0xd5dd33650Ef1DC6D23069aEDC8EAE87b0D3619B2`](https://sepolia.scrollscan.com/address/0xd5dd33650Ef1DC6D23069aEDC8EAE87b0D3619B2)
 
 #### Aave
 
@@ -209,7 +209,7 @@ See this [Github gist](https://gist.github.com/dghelm/7fe68f0a524f30846e1142721c
 
 ### Additional Useful Contracts
 
-- Multicall3: `0xcA11bde05977b3631167028862bE2a173976CA11`
+- Multicall3: [`0xcA11bde05977b3631167028862bE2a173976CA11`](https://sepolia.scrollscan.com/address/0xcA11bde05977b3631167028862bE2a173976CA11)
 
 ### Tokens
 
@@ -218,4 +218,4 @@ See this [Github gist](https://gist.github.com/dghelm/7fe68f0a524f30846e1142721c
   [token-list](https://github.com/scroll-tech/token-list/tree/sepolia) repo's `sepolia` branch.
 </Aside>
 
-- Gho Token: `0xD9692f1748aFEe00FACE2da35242417dd05a8615`
+- Gho Token: [`0xD9692f1748aFEe00FACE2da35242417dd05a8615`](https://sepolia.scrollscan.com/address/0xD9692f1748aFEe00FACE2da35242417dd05a8615)


### PR DESCRIPTION
## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

closes #109 

## Description

<!-- Please provide enough information so that others can review your pull request: -->

Replaces the plain text contract addresses with URLs that link them to the appropriate pages on Scrollscan or Etherscan (or the corresponding Sepolia explorer pages)

## Changes

<!--Explain the **details** for making this change. What existing problem does the pull request solve? -->

- Replace plain texts with links
