### PR TITLE
Add video tutorial + Atlas to docs

### DIFF
--- a/src/content/docs/en/developers/developer-quickstart.mdx
+++ b/src/content/docs/en/developers/developer-quickstart.mdx
@@ -26,7 +26,9 @@ Scroll uses ETH as its native currency, which will be needed to pay transaction 
 
 To start building on Scroll, we suggest you begin with using our Scroll Sepolia testnet. You'll first need to acquire some testnet ETH. See the [Faucet](/user-guide/faucet) page for tips on getting test tokens on Sepolia. After this, you can bridge your testnet ETH to the Scroll Sepolia Testnet (Layer 2) using our [Sepolia Bridge](https://sepolia.scroll.io/bridge), as described in the [Bridge article](/user-guide/bridge).
 
-For a walkthrough, start with the User Guide's [Setup](/user-guide/setup) page.
+For a walkthrough, start with the User Guide's [Setup](/user-guide/setup) page. We also have a full video tutorial of setting up Metamask, getting testnet tokens, bridging to Scroll, and deploying below.
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/Kdg-n298HuQ?si=j3ml3xkI3iYL5Qpt" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 Once you're ready to deploy on Scroll's mainnet, you can bridge over ETH using [our native bridge](https://scroll.io/bridge/) or one of the 3rd-party bridges.
 
@@ -111,6 +113,14 @@ To deploy using the Scroll Sepolia Testnet Public RPC, run:
 ```bash
 forge create ... --rpc-url=https://sepolia-rpc.scroll.io/ --legacy
 ```
+
+### Atlas
+
+1. Go to https://app.atlaszk.com
+2. Go to the top right and change the network to Scroll
+3. Press Deploy
+
+That's it!
 
 ### Remix Web IDE
 

--- a/src/content/docs/en/developers/guides/contract-deployment-tutorial.mdx
+++ b/src/content/docs/en/developers/guides/contract-deployment-tutorial.mdx
@@ -10,7 +10,7 @@ whatsnext: { "Scroll Messenger Cross-chain Interaction": "/developers/guides/scr
 
 import Aside from "../../../../../components/Aside.astro"
 
-The Scroll Sepolia Testnet allows anyone to deploy a smart contract on Scroll. In this tutorial, you will learn how to deploy a contract on Scroll Sepolia using common tools for developing on Ethereum. This [demo repo](https://github.com/scroll-tech/scroll-guides/tree/main/contract-deploy-demo) illustrates contract deployment with [Hardhat](https://hardhat.org/) and [Foundry](https://github.com/foundry-rs/foundry).
+The Scroll Sepolia Testnet allows anyone to deploy a smart contract on Scroll. In this tutorial, you will learn how to deploy a contract on Scroll Sepolia using common tools for developing on Ethereum. This [demo repo](https://github.com/scroll-tech/scroll-guides/tree/main/contract-deploy-demo) illustrates contract deployment with [Hardhat](https://hardhat.org/) and [Foundry](https://github.com/foundry-rs/foundry). We also have a [video tutorial](https://www.youtube.com/embed/Kdg-n298HuQ?si=j3ml3xkI3iYL5Qpt) for deploying with [Atlas](https://app.atlaszk.com).
 
 <Aside type="tip" title="Got Testnet ETH?">
   Before you start deploying the contract, you need to request test tokens from a Sepolia faucet and use the
@@ -18,6 +18,13 @@ The Scroll Sepolia Testnet allows anyone to deploy a smart contract on Scroll. I
   could acquire Scroll Sepolia ETH directly. See our [Faucet](/user-guide/faucet/) and [Bridge](/user-guide/bridge/)
   guides for help.
 </Aside>
+
+## Deploy contracts with Atlas
+
+0. [Get Metamask, sepolia eth, and bridge it to Scroll](https://www.youtube.com/embed/Kdg-n298HuQ?si=j3ml3xkI3iYL5Qpt) 
+1. Go to https://app.atlaszk.com
+2. Go to the top right and change the network to Scroll / Scroll testnet
+3. Press Deploy
 
 ## Deploy contracts with Hardhat
 


### PR DESCRIPTION
## Description

Adding video tutorial for new developers that walks through metamask setup, getting testnet eth, bridging to sepolia, and deploying.

Also adds deploy instructions using Atlas

## Changes

Developer quickstart and contract deployment tutorial