### PR TITLE
update: add Trail of Bits links for zkEVM circuits

### DIFF
--- a/src/content/docs/en/technology/security/audits-and-bug-bounty.mdx
+++ b/src/content/docs/en/technology/security/audits-and-bug-bounty.mdx
@@ -25,17 +25,12 @@ Scroll has worked with several industry-leading security audit firms to review o
 - OpenZeppelin and Zellic have performed independent audits on our bridge & rollup contracts
 - Trail of Bits has analyzed our node implementation
 
-<Aside type="tip" title="">
-  We're still working with partners to get all of our reports published. We'll update this page with links as they
-  become available.
-</Aside>
-
 ### zkEVM circuits
 
 - Trail of Bits
-  - Wave 1
-  - Wave 2
-  - Wave 3
+  - [Wave 1](https://github.com/trailofbits/publications/blob/master/reviews/2023-04-scroll-zkEVM-wave1-securityreview.pdf)
+  - [Wave 2](https://github.com/trailofbits/publications/blob/master/reviews/2023-08-scroll-zkEVM-wave2-securityreview.pdf)
+  - [Wave 3](https://github.com/trailofbits/publications/blob/master/reviews/2023-09-scroll-zkEVM-wave3-securityreview.pdf)
 - Zellic and Kalos
   - [Wave 1](https://github.com/Zellic/publications/blob/master/Scroll%20zkEVM%20-%20Part%201%20Audit%20Report.pdf)
   - [Wave 2](https://github.com/Zellic/publications/blob/master/Scroll%20zkEVM%20-%20Part%202%20Audit%20Report.pdf)

--- a/src/content/docs/en/technology/security/audits-and-bug-bounty.mdx
+++ b/src/content/docs/en/technology/security/audits-and-bug-bounty.mdx
@@ -39,7 +39,7 @@ Scroll has worked with several industry-leading security audit firms to review o
 
 - Trail of Bits
   - [zkTrie](https://github.com/trailofbits/publications/blob/master/reviews/2023-07-scroll-zktrie-securityreview.pdf)
-  - L2geth
+  - [L2geth](https://github.com/trailofbits/publications/blob/master/reviews/2023-08-scrollL2geth-initial-securityreview.pdf)
   - [L2geth diff](https://github.com/trailofbits/publications/blob/master/reviews/2023-08-scrollL2geth-securityreview.pdf)
 
 ### Bridge and rollup contract


### PR DESCRIPTION
Adds links for newly released audits.