### PR TITLE
fix address of L1ScrollMessenger and gasLimit for L1->L2 bridging

### DIFF
--- a/src/content/docs/en/developers/guides/scroll-messenger-cross-chain-interaction.mdx
+++ b/src/content/docs/en/developers/guides/scroll-messenger-cross-chain-interaction.mdx
@@ -79,12 +79,12 @@ contract GreeterOperator {
 We pass the message by executing `executeFunctionCrosschain` and passing the following parameters:
 
 - `scrollMessengerAddress`: This will depend on where you deployed the `GreeterOperator` contract.
-  - If you deployed it on Sepolia use `0x50c7d3e7f7c656493D1D76aaa1a836CedfCBB16A`. If you deployed on Scroll use `0xBa50f5340FB9F3Bd074bD638c9BE13eCB36E603d`.
+  - If you deployed it on Sepolia use `0x50c7d3e7f7c656493D1D76aaa1a836CedfCBB16A`. If you deployed on Scroll use `0x781e90f1c8Fc4611c9b7497C3B47F99Ef6969CbC`.
 - `targetAddress`: The address of the `Greeter` contract on the opposite chain.
 - `value`: In this case, it is `0` because the `setGreeting`is not payable.
 - `greeting`: This is the parameter that will be sent through the message. Try passing `“This message was crosschain!”`
 - `gasLimit`:
-  - If you are sending the message from L1 to L2, around `5000` gas limit should be more than enough.
+  - If you are sending the message from L1 to L2, around `1000000` gas limit should be more than enough.
   - If you are sending the message from L2 to L1, pass `0`, as the transaction be completed by executing an additional transaction on L1.
 
 ### Relay the Message when sending from L2 to L1

--- a/src/content/docs/es/developers/guides/scroll-messenger-cross-chain-interaction.mdx
+++ b/src/content/docs/es/developers/guides/scroll-messenger-cross-chain-interaction.mdx
@@ -78,12 +78,12 @@ contract GreeterOperator {
 Pasamos el mensaje ejecutando `executeFunctionCrosschain` y pasando los siguientes parámetros:
 
 - `scrollMessengerAddress`: Esto dependerá de dónde hayas desplegado el contrato `GreeterOperator`.
-  - Si lo desplegaste en Sepolia utiliza `0x50c7d3e7f7c656493D1D76aaa1a836CedfCBB16A`. Si lo has desplegado en Scroll utiliza `0xBa50f5340FB9F3Bd074bD638c9BE13eCB36E603d`.
+  - Si lo desplegaste en Sepolia utiliza `0x50c7d3e7f7c656493D1D76aaa1a836CedfCBB16A`. Si lo has desplegado en Scroll utiliza `0x781e90f1c8Fc4611c9b7497C3B47F99Ef6969CbC`.
 - `targetAddress`: La dirección del contrato `Greeter` en la cadena opuesta.
 - `value`: En este caso es `0` porque el `setGreeting` no es de tipo `payable`.
 - `greeting`: Es el parámetro que se enviará a través del mensaje. Prueba pasar `"¡Este mensaje fue ejecutado de manera crosschain!"`.
 - `gasLimit`:
-  - Si estás enviando el mensaje de L1 a L2, alrededor de un límite de gas de `5000` debería ser más que suficiente.
+  - Si estás enviando el mensaje de L1 a L2, alrededor de un límite de gas de `1000000` debería ser más que suficiente.
   - Si estás enviando el mensaje de L2 a L1, pasa `0`, ya que la transacción se completará ejecutando una transacción adicional en L1.
 
 ### Retransmisión del mensaje al enviar de L2 a L1


### PR DESCRIPTION
## Closing issues

closes #144

## Description

+ The address of `L1ScrollMessenger` is incorrect in a few docs.
+ The `gasLimit` should not be `5000`. It is not enough. Changing to `1000000` should be better.

## Changes

+ Change `0xBa50f5340FB9F3Bd074bD638c9BE13eCB36E603d` to `0x781e90f1c8Fc4611c9b7497C3B47F99Ef6969CbC`
+ Change `5000` to `1000000`.
