### PR TITLE
Feb2024 Bridge Updates #1

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -113,6 +113,7 @@
       "introduction": "Introduction",
       "principles": "Principles",
       "scrollArchitecture": "Scroll Architecture",
+      "scrollUpgrades": "Scroll Upgrades",
       "overview": "Overview",
 
       "scrollChain": "Scroll Chain",

--- a/src/config/sidebar.ts
+++ b/src/config/sidebar.ts
@@ -181,7 +181,13 @@ export const getSidebar = () => {
     technology: [
       {
         section: t("sidebar.technology.overview"),
-        contents: [{ title: t("sidebar.technology.scrollArchitecture"), url: formatUrl("technology") }],
+        contents: [
+          { title: t("sidebar.technology.scrollArchitecture"), url: formatUrl("technology") },
+          {
+            title: t("sidebar.technology.scrollUpgrades"),
+            url: "technology/overview/scroll-upgrades",
+          },
+        ],
       },
       {
         section: t("sidebar.technology.scrollChain"),

--- a/src/content/docs/en/developers/guides/estimating-gas-and-tx-fees.mdx
+++ b/src/content/docs/en/developers/guides/estimating-gas-and-tx-fees.mdx
@@ -35,7 +35,7 @@ For a more comprehensive explanation and details on the formula, check the docum
 
 ## Interfacing with values
 
-To fetch these values and calculate the final fee, we’ll interact with Scroll’s public RPC and pre-deployed Smart Contract L1GasOracle.sol, which is deployed at [`TODO: 0x5300000000000000000000000000000000000002`](TODO: https://blockscout.scroll.io/address/0x5300000000000000000000000000000000000002)
+To fetch these values and calculate the final fee, we’ll interact with Scroll’s public RPC and pre-deployed Smart Contract `L1GasOracle.sol`, deployed at [`0x5300000000000000000000000000000000000002`](https://scrollscan.com/address/0x5300000000000000000000000000000000000002).
 
 For our example codebase, we make a Hardhat project and fetch values using the [Ethers.js](https://docs.ethers.org/v6/) library.
 

--- a/src/content/docs/en/developers/l1-and-l2-bridging.mdx
+++ b/src/content/docs/en/developers/l1-and-l2-bridging.mdx
@@ -9,6 +9,7 @@ excerpt: "An overview of Scroll's Bridging architecture"
 ---
 
 import ClickToZoom from "../../../../components/ClickToZoom.astro"
+import Aside from "../../../../components/Aside.astro"
 import L1GatewayWHITE from "../../../../assets/images/developers/L1GatewayWHITE.png"
 import withdrawWHITE from "../../../../assets/images/developers/withdrawWHITE.png"
 
@@ -22,9 +23,17 @@ In addition to token transfers, the Scroll Messenger contract enables cross-chai
 
 ## L1 Gateway architecture
 
+
 <ClickToZoom src={L1GatewayWHITE} />
 
 There are many entry points from the user to the Scroll bridge. This will depend on what you want to do and how you want to do it. If you want to send ETH or ERC20 tokens, you should use the `GatewayRouter` . If you want to send NFTs, you should use the `L1ERC721Gateway` or `L1ERC1155Gateway`. If you want to send arbitrary data, you should use the `L1ScrollMessenger`. All Gateway transfers use the Scroll Messenger to send assets cross-chain, whose job is to append the transactions to the Message Queue for L2 inclusion.
+
+<Aside type="tip" title="Upgrade Notice">
+With the February 2024 Bridge Upgrade, minor changes will be made to the above flow. Most notably, `L1GatewayRouter` will now bypass `L1ETHGateway` when bridging ETH to improve gas efficiency.
+
+The upgrade is expected to be finalized on February 19th, 2024 after a two-week timelock. Scroll Sepolia has already undergone this upgrade. Read more [here](https://scroll.io/blog/to-do-slug).
+
+</Aside>
 
 ## L2 Gateway architecture
 
@@ -33,3 +42,10 @@ There are many entry points from the user to the Scroll bridge. This will depend
 Regarding possible permissionlessly callable entry points, the L2 Gateway Architecture is very similar to L1. The difference is that when sending a message from L2, calling the `appendMessage` function will store the message in an append-only binary merkle tree (aka withdraw tree) in the `L2MessageQueue`. When a new message is sent to the `L2MessageQueue`, the relayer will detect it and store it in the database. When the block is finalized, it will generate a proof of the new merkle path and pass it to the L1geth node to execute on `L1ScrollMessenger` . All finalized withdraw roots will be stored in the rollup contract so we can verify the proof against them. In the next Scroll versions, the Relayer won't be needed since all users will be able to finalize the transaction on L1.
 
 In the upcoming sections, we will explore the technical aspects of the bridge, including the smart contract API required to utilize its capabilities. Detailed guides with code examples are provided in the Developer Guides section to assist developers and users in understanding and implementing these functionalities.
+
+<Aside type="tip" title="Upgrade Notice">
+With the February 2024 Bridge Upgrade, minor changes will be made to the above flow. Most notably, `L2GatewayRouter` will now bypass `L2ETHGateway` when bridging ETH to improve gas efficiency.
+
+The upgrade is expected to be finalized on February 19th, 2024 after a two-week timelock. Scroll Sepolia has already undergone this upgrade. Read more [here](https://scroll.io/blog/to-do-slug).
+
+</Aside>

--- a/src/content/docs/en/developers/l1-and-l2-bridging.mdx
+++ b/src/content/docs/en/developers/l1-and-l2-bridging.mdx
@@ -28,13 +28,6 @@ In addition to token transfers, the Scroll Messenger contract enables cross-chai
 
 There are many entry points from the user to the Scroll bridge. This will depend on what you want to do and how you want to do it. If you want to send ETH or ERC20 tokens, you should use the `GatewayRouter` . If you want to send NFTs, you should use the `L1ERC721Gateway` or `L1ERC1155Gateway`. If you want to send arbitrary data, you should use the `L1ScrollMessenger`. All Gateway transfers use the Scroll Messenger to send assets cross-chain, whose job is to append the transactions to the Message Queue for L2 inclusion.
 
-<Aside type="tip" title="Upgrade Notice">
-With the February 2024 Bridge Upgrade, minor changes will be made to the above flow. Most notably, `L1GatewayRouter` will now bypass `L1ETHGateway` when bridging ETH to improve gas efficiency.
-
-The upgrade is expected to be finalized on February 19th, 2024 after a two-week timelock. Scroll Sepolia has already undergone this upgrade. Read more [here](https://scroll.io/blog/to-do-slug).
-
-</Aside>
-
 ## L2 Gateway architecture
 
 <ClickToZoom src={withdrawWHITE} />
@@ -42,10 +35,3 @@ The upgrade is expected to be finalized on February 19th, 2024 after a two-week 
 Regarding possible permissionlessly callable entry points, the L2 Gateway Architecture is very similar to L1. The difference is that when sending a message from L2, calling the `appendMessage` function will store the message in an append-only binary merkle tree (aka withdraw tree) in the `L2MessageQueue`. When a new message is sent to the `L2MessageQueue`, the relayer will detect it and store it in the database. When the block is finalized, it will generate a proof of the new merkle path and pass it to the L1geth node to execute on `L1ScrollMessenger` . All finalized withdraw roots will be stored in the rollup contract so we can verify the proof against them. In the next Scroll versions, the Relayer won't be needed since all users will be able to finalize the transaction on L1.
 
 In the upcoming sections, we will explore the technical aspects of the bridge, including the smart contract API required to utilize its capabilities. Detailed guides with code examples are provided in the Developer Guides section to assist developers and users in understanding and implementing these functionalities.
-
-<Aside type="tip" title="Upgrade Notice">
-With the February 2024 Bridge Upgrade, minor changes will be made to the above flow. Most notably, `L2GatewayRouter` will now bypass `L2ETHGateway` when bridging ETH to improve gas efficiency.
-
-The upgrade is expected to be finalized on February 19th, 2024 after a two-week timelock. Scroll Sepolia has already undergone this upgrade. Read more [here](https://scroll.io/blog/to-do-slug).
-
-</Aside>

--- a/src/content/docs/en/developers/scroll-contracts.mdx
+++ b/src/content/docs/en/developers/scroll-contracts.mdx
@@ -70,7 +70,7 @@ Use the table below to configure your Ethereum tools to the Scroll mainnet.
   - L2 ERC1155 Gateway: [`0x62597Cc19703aF10B58feF87B0d5D29eFE263bcc`](https://scrollscan.com/address/0x62597Cc19703aF10B58feF87B0d5D29eFE263bcc)
 - Gas Oracle (deployed on Mainnet)
   - L2 Gas Oracle (*soon to be deprecated*): [`0x987e300fDfb06093859358522a79098848C33852`](https://etherscan.io/address/0x987e300fDfb06093859358522a79098848C33852)
-  - *after [Feb '24 Bridge Upgrade](https://scroll.io/blog/to-replace-slug)*
+  - *after [Feb '24 Bridge Upgrade](https://scroll.io/blog/protocol-upgrade-bridging-cost-reduction)*
     - L2 Message Queue With Gas Price Oracle: [`0x0d7E906BD9cAFa154b048cFa766Cc1E54E39AF9B`](https://etherscan.io/address/0x0d7E906BD9cAFa154b048cFa766Cc1E54E39AF9B)
 
 ### L2 Predeploys

--- a/src/content/docs/en/developers/scroll-contracts.mdx
+++ b/src/content/docs/en/developers/scroll-contracts.mdx
@@ -44,8 +44,8 @@ Use the table below to configure your Ethereum tools to the Scroll mainnet.
 
 ### ETH and ERC20 Bridge
 
-- L1 ERC20 Gateway Router: [`0xF8B1378579659D8F7EE5f3C929c2f3E332E41Fd6`](https://etherscan.io/address/0xF8B1378579659D8F7EE5f3C929c2f3E332E41Fd6)
-- L2 ERC20 Gateway Router: [`0x4C0926FF5252A435FD19e10ED15e5a249Ba19d79`](https://scrollscan.com/address/0x4C0926FF5252A435FD19e10ED15e5a249Ba19d79)
+- L1 Gateway Router: [`0xF8B1378579659D8F7EE5f3C929c2f3E332E41Fd6`](https://etherscan.io/address/0xF8B1378579659D8F7EE5f3C929c2f3E332E41Fd6)
+- L2 Gateway Router: [`0x4C0926FF5252A435FD19e10ED15e5a249Ba19d79`](https://scrollscan.com/address/0x4C0926FF5252A435FD19e10ED15e5a249Ba19d79)
 
 ### Advanced Bridge Contracts
 
@@ -68,8 +68,10 @@ Use the table below to configure your Ethereum tools to the Scroll mainnet.
 - ERC1155 Bridge
   - L1 ERC1155 Gateway: [`0xb94f7F6ABcb811c5Ac709dE14E37590fcCd975B6`](https://etherscan.io/address/0xb94f7F6ABcb811c5Ac709dE14E37590fcCd975B6)
   - L2 ERC1155 Gateway: [`0x62597Cc19703aF10B58feF87B0d5D29eFE263bcc`](https://scrollscan.com/address/0x62597Cc19703aF10B58feF87B0d5D29eFE263bcc)
-- Gas Oracle
-  - L2 Gas Oracle (deployed on Mainnet): [`0x987e300fDfb06093859358522a79098848C33852`](https://scrollscan.com/address/0x987e300fDfb06093859358522a79098848C33852)
+- Gas Oracle (deployed on Mainnet)
+  - L2 Gas Oracle (*soon to be deprecated*): [`0x987e300fDfb06093859358522a79098848C33852`](https://etherscan.io/address/0x987e300fDfb06093859358522a79098848C33852)
+  - *after [Feb '24 Bridge Upgrade](https://scroll.io/blog/to-replace-slug)*
+    - L2 Message Queue With Gas Price Oracle: [`0x0d7E906BD9cAFa154b048cFa766Cc1E54E39AF9B`](https://etherscan.io/address/0x0d7E906BD9cAFa154b048cFa766Cc1E54E39AF9B)
 
 ### L2 Predeploys
 
@@ -155,8 +157,8 @@ Use the table below to configure your Ethereum tools to the Scroll Sepolia Testn
 
 #### ETH and ERC20 Bridge
 
-- L1 ERC20 Gateway Router: [`0x13FBE0D0e5552b8c9c4AE9e2435F38f37355998a`](https://sepolia.etherscan.io/address/0x13FBE0D0e5552b8c9c4AE9e2435F38f37355998a)
-- L2 ERC20 Gateway Router: [`0x9aD3c5617eCAa556d6E166787A97081907171230`](https://sepolia.scrollscan.com/address/0x9aD3c5617eCAa556d6E166787A97081907171230)
+- L1 Gateway Router: [`0x13FBE0D0e5552b8c9c4AE9e2435F38f37355998a`](https://sepolia.etherscan.io/address/0x13FBE0D0e5552b8c9c4AE9e2435F38f37355998a)
+- L2 Gateway Router: [`0x9aD3c5617eCAa556d6E166787A97081907171230`](https://sepolia.scrollscan.com/address/0x9aD3c5617eCAa556d6E166787A97081907171230)
 
 #### Advanced Bridge Contracts
 
@@ -179,8 +181,9 @@ Use the table below to configure your Ethereum tools to the Scroll Sepolia Testn
 - ERC1155 Bridge
   - L1 ERC1155 Gateway: [`0xa5Df8530766A85936EE3E139dECE3bF081c83146`](https://sepolia.etherscan.io/address/0xa5Df8530766A85936EE3E139dECE3bF081c83146)
   - L2 ERC1155 Gateway: [`0xe17C9b9C66FAF07753cdB04316D09f52144612A5`](https://sepolia.scrollscan.com/address/0xe17C9b9C66FAF07753cdB04316D09f52144612A5)
-- Gas Oracle
-  - L2 Gas Oracle (deployed on Sepolia): [`0x247969F4fad93a33d4826046bc3eAE0D36BdE548`](https://sepolia.scrollscan.com/address/0x247969F4fad93a33d4826046bc3eAE0D36BdE548)
+- Gas Oracle (deployed on Sepolia)
+  - L1 Message Queue With Gas Price Oracle: [`0xF0B2293F5D834eAe920c6974D50957A1732de763`](https://sepolia.etherscan.io/address/0xF0B2293F5D834eAe920c6974D50957A1732de763)
+  - L2 Gas Oracle (*deprecated*): [`0x247969F4fad93a33d4826046bc3eAE0D36BdE548`](https://sepolia.etherscan.io/address/0x247969F4fad93a33d4826046bc3eAE0D36BdE548)
 
 #### L2 Predeploys
 

--- a/src/content/docs/en/developers/transaction-fees-on-scroll.mdx
+++ b/src/content/docs/en/developers/transaction-fees-on-scroll.mdx
@@ -175,10 +175,12 @@ On mainnet, the `L2GasPriceOracle` is deployed at [`0x987e300fDfb06093859358522a
 
 On Sepolia, an upgraded `L1MessageQueueWithGasPriceOracle` should be used, deployed to [`0xF0B2293F5D834eAe920c6974D50957A1732de763`](https://sepolia.etherscan.io/address/0xF0B2293F5D834eAe920c6974D50957A1732de763).
 
+If your system supports off-chain mechanisms, you can also call `eth_estimateGas` and `eth_gasPrice` on any Scroll RPC node to get an estimate of the gas required for a given transaction.
+
 <Aside type="danger" title="Upgrade Notice">
 After the February 2024 Bridge Upgrade, `L1GasPriceOracle` will be deprecated in favor of `L1MessageQueueWithGasPriceOracle`, which will be available at [`0x0d7E906BD9cAFa154b048cFa766Cc1E54E39AF9B`](https://etherscan.io/address/0x0d7E906BD9cAFa154b048cFa766Cc1E54E39AF9B).
 
-The upgrade is expected to be finalized on February 21, 2024 after a two-week timelock. Scroll Sepolia has already undergone this upgrade. Read more [here](https://scroll.io/blog/protocol-upgrade-bridging-cost-reduction).
+The upgrade is expected to be finalized on February 21, 2024, after a two-week timelock. Scroll Sepolia has already undergone this upgrade. Read more [here](https://scroll.io/blog/protocol-upgrade-bridging-cost-reduction).
 
 </Aside>
 {/* TODO: Add full documentation of key methods */}

--- a/src/content/docs/en/developers/transaction-fees-on-scroll.mdx
+++ b/src/content/docs/en/developers/transaction-fees-on-scroll.mdx
@@ -167,7 +167,9 @@ Computes the amount of L1 gas used for a transaction. Adds the overhead which re
 
 ## L1 Originated Transactions
 
-When messaging from L1 to L2, the user does not pay the L1 fee but may need to know how much L2 gas to pay. Contracts on L1 can use an L2 Gas Price Oracle deployed to the L1 to get the gas fee for a given transaction. The oracle also exposes the current l2BaseFee and estimated cross-domain message fee for a given gas limit.
+When messaging from L1 to L2, the user pays all transaction fees on L1. The user pays L1 gas fees, but because of this, doesn't need to pay Scroll an L1 Data Fee. They will need to account for L2 Execution Fees in their L1 transaction though, and will need to know how much L2 gas to pay.
+
+Contracts on L1 can use an L2 Gas Price Oracle deployed to the L1 to get the gas fee for a given transaction. The oracle also exposes the current l2BaseFee and estimated cross-domain message fee for a given gas limit.
 
 On mainnet, the `L2GasPriceOracle` is deployed at [`0x987e300fDfb06093859358522a79098848C33852`](https://etherscan.io/address/0x987e300fDfb06093859358522a79098848C33852).
 
@@ -176,7 +178,7 @@ On Sepolia, an upgraded `L1MessageQueueWithGasPriceOracle` should be used, deplo
 <Aside type="danger" title="Upgrade Notice">
 After the February 2024 Bridge Upgrade, `L1GasPriceOracle` will be deprecated in favor of `L1MessageQueueWithGasPriceOracle`, which will be available at [`0x0d7E906BD9cAFa154b048cFa766Cc1E54E39AF9B`](https://etherscan.io/address/0x0d7E906BD9cAFa154b048cFa766Cc1E54E39AF9B).
 
-The upgrade is expected to be finalized on February 19th, 2024 after a two-week timelock. Scroll Sepolia has already undergone this upgrade. Read more [here](https://scroll.io/blog/to-do-slug).
+The upgrade is expected to be finalized on February 21, 2024 after a two-week timelock. Scroll Sepolia has already undergone this upgrade. Read more [here](https://scroll.io/blog/protocol-upgrade-bridging-cost-reduction).
 
 </Aside>
 {/* TODO: Add full documentation of key methods */}

--- a/src/content/docs/en/developers/transaction-fees-on-scroll.mdx
+++ b/src/content/docs/en/developers/transaction-fees-on-scroll.mdx
@@ -140,7 +140,7 @@ Returns the latest known l1 base fee
 #### getL1Fee
 
 ```solidity
-function getL1Fee(bytes memory _data) external view returns (uint256);
+function getL1Fee(bytes memory data) external view returns (uint256);
 ```
 
 Computes the L1 portion of the fee based on the size of the RLP encoded input transaction, the current L1 base fee, and the various dynamic parameters.
@@ -165,10 +165,26 @@ Computes the amount of L1 gas used for a transaction. Adds the overhead which re
 | --------- | ----------------------------------------------------------- |
 | data      | Signed fully RLP-encoded transaction to get the L1 fee for. |
 
+## L1 Originated Transactions
+
+When messaging from L1 to L2, the user does not pay the L1 fee but may need to know how much L2 gas to pay. Contracts on L1 can use an L2 Gas Price Oracle deployed to the L1 to get the gas fee for a given transaction. The oracle also exposes the current l2BaseFee and estimated cross-domain message fee for a given gas limit.
+
+On mainnet, the `L2GasPriceOracle` is deployed at [`0x987e300fDfb06093859358522a79098848C33852`](https://etherscan.io/address/0x987e300fDfb06093859358522a79098848C33852).
+
+On Sepolia, an upgraded `L1MessageQueueWithGasPriceOracle` should be used, deployed to [`0xF0B2293F5D834eAe920c6974D50957A1732de763`](https://sepolia.etherscan.io/address/0xF0B2293F5D834eAe920c6974D50957A1732de763).
+
+<Aside type="danger" title="Upgrade Notice">
+After the February 2024 Bridge Upgrade, `L1GasPriceOracle` will be deprecated in favor of `L1MessageQueueWithGasPriceOracle`, which will be available at [`0x0d7E906BD9cAFa154b048cFa766Cc1E54E39AF9B`](https://etherscan.io/address/0x0d7E906BD9cAFa154b048cFa766Cc1E54E39AF9B).
+
+The upgrade is expected to be finalized on February 19th, 2024 after a two-week timelock. Scroll Sepolia has already undergone this upgrade. Read more [here](https://scroll.io/blog/to-do-slug).
+
+</Aside>
+{/* TODO: Add full documentation of key methods */}
+
 ## Future Roadmap
 
-Currently, the computation required for proof generation is completed by and subsidized by Scroll and various proving partners.
+Currently, the computation required for proof generation and gas for proof verification on L1 is subsidized by Scroll and various proving partners. It is partially covered by setting a floor to L2 Gas Price.
 
 As the prover network becomes decentralized, incentives for proof generation will need to be incorporated into the protocol for the system to be sustainable and scalable.
 
-We expect the final gas cost will include the cost of this proof generation. With further protocol optimization, this cost for the user should be minimal, as each proof covers many transactions.
+We expect the final gas cost will explicitly include the cost of this proof generation. With further protocol optimization, this cost for the user should be minimal, as each proof covers many transactions.

--- a/src/content/docs/en/technology/bridge/cross-domain-messaging.mdx
+++ b/src/content/docs/en/technology/bridge/cross-domain-messaging.mdx
@@ -8,6 +8,7 @@ whatsnext: { "Deposit Gateways": "/technology/bridge/deposit-gateways/" }
 ---
 
 import ClickToZoom from "../../../../../components/ClickToZoom.astro"
+import Aside from "../../../../../components/Aside.astro"
 import ToggleElement from "../../../../../components/ToggleElement.astro"
 
 import L1ToL2 from "../_images/L1-to-L2.png"
@@ -21,6 +22,10 @@ Scroll has an arbitrary message passing bridge that enables token transfers and 
 <ClickToZoom src={L1ToL2} alt="L1 to L2 workflow" caption="Figure 1. L1 to L2 message relay workflow" />
 
 There are two primary approaches to sending a message from L1 to L2: sending arbitrary messages via `L1ScrollMessenger` and sending enforced transactions via `EnforcedTxGateway`. Both approaches allow users to initiate a L2 transaction on L1 and call arbitrary contracts on L2. For arbitrary messages, the sender of the L2 transactions is the aliased `L1ScrollMessenger` address. For enforced transactions, the L2 sender is an externally-owned account (EOA). In addition, we provide several standard token gateways to make it easier for users to deposit ETH and other standard tokens including ERC-20, ERC-677, ERC-721, and ERC-1155. In essence, these gateways encode token deposits into a message and send it to their counterparts on L2 through the `L1ScrollMessenger` contract. You can find more details about the L1 token gateways in the [Deposit Gateways](/technology/bridge/deposit-gateways).
+
+<Aside type="danger" title="">
+Enforced Transactions are not yet enabled on Scroll. In future upgrades, users will be able to use this functionality to bypass the `L1ScrollMessenger` and send messages directly to the `L1MessageQueue`.
+</Aside>
 
 As depicted in Figure 1, both arbitrary messages and enforced transactions are appended to the message queue stored in the `L1MessageQueue` contract. The `L1MessageQueue` contract provides two functions `appendCrossDomainMessage` and `appendEnforcedTransaction` for appending arbitrary messages and enforced transactions respectively.
 
@@ -112,6 +117,10 @@ The deposited ETH of `value` amount is locked in the `L1ScrollMessenger` contrac
 
 ### Sending Enforced Transactions
 
+<Aside type="danger" title="">
+Enforced Transactions are not yet enabled on Scroll. In future upgrades, users will be able to use this functionality to bypass the `L1ScrollMessenger` and send messages directly to the `L1MessageQueue`.
+</Aside>
+
 The `EnforcedTxGateway` contract provides two `sendTransaction` functions to send an enforced transaction. In the first function, the sender of the generated `L1MessageTx` transaction is the transaction sender. On the other hand, the second function uses the passed `sender` address as the sender of the `L1MessageTx` transaction. This allows a third party to send an enforced transaction on behalf of the user and pay the relay fee. Note that the second function requires providing a valid signature of the generated `L1MessageTx` transaction that matches the `sender` address. Both `sendTransaction` functions enforce the sender to be an EOA account.
 
 <ToggleElement anchor="sendTransaction function signatures">
@@ -184,6 +193,13 @@ Because the `L2ScrollMessenger` contract records all L1 messages that were succe
 ### Message Relay Fee
 
 The contract `L2GasPriceOracle` deployed on L1 computes the relay fee of a message given its gas limit. This contract stores the `l2BaseFee` in its storage, which is updated by a dedicated relayer run by Scroll currently. The relay fee of L1-to-L2 messages is `gasLimit * l2BaseFee`.
+
+<Aside type="tip" title="Upgrade Notice">
+During the February 2024 Bridge Upgrade, `L2GasPriceOracle` will be deprecated, with its functionality moved into the `L1MessageQueueWithGasPriceOracle` contract.
+
+The upgrade is expected to be finalized on February 19th, 2024 after a two-week timelock. Scroll Sepolia has already undergone this upgrade. Read more [here](https://scroll.io/blog/to-do-slug).
+
+</Aside>
 
 ### Address Alias
 

--- a/src/content/docs/en/technology/bridge/cross-domain-messaging.mdx
+++ b/src/content/docs/en/technology/bridge/cross-domain-messaging.mdx
@@ -197,7 +197,7 @@ The contract `L2GasPriceOracle` deployed on L1 computes the relay fee of a messa
 <Aside type="tip" title="Upgrade Notice">
 During the February 2024 Bridge Upgrade, `L2GasPriceOracle` will be deprecated, with its functionality moved into the `L1MessageQueueWithGasPriceOracle` contract.
 
-The upgrade is expected to be finalized on February 19th, 2024 after a two-week timelock. Scroll Sepolia has already undergone this upgrade. Read more [here](https://scroll.io/blog/to-do-slug).
+The upgrade is expected to be finalized on February 21, 2024, after a two-week timelock. Scroll Sepolia has already undergone this upgrade. Read more [here](https://scroll.io/blog/protocol-upgrade-bridging-cost-reduction).
 
 </Aside>
 

--- a/src/content/docs/en/technology/bridge/deposit-gateways.mdx
+++ b/src/content/docs/en/technology/bridge/deposit-gateways.mdx
@@ -23,13 +23,6 @@ This document describes how users and developers can utilize gateways to deposit
 | `L1ERC721Gateway`        | The gateway for ERC-721 token deposits.                          |
 | `L1ERC1155Gateway`       | The gateway for ERC-1155 token deposits.                         |
 
-<Aside type="tip" title="Upgrade Notice">
-With the February 2024 Bridge Upgrade, `L1GatewayRouter` will now bypass `L1ETHGateway` when bridging ETH to improve gas efficiency.
-
-The upgrade is expected to be finalized on February 19th, 2024 after a two-week timelock. Scroll Sepolia has already undergone this upgrade. Read more [here](https://scroll.io/blog/to-do-slug).
-
-</Aside>
-
 ## Overview
 
 <ClickToZoom src={DepositWorkflow} alt="Deposit Workflow" />
@@ -65,11 +58,6 @@ Scroll treats ETH as its native token. We pre-allocate a sufficient amount of ET
    In the case of ETH deposit, the `relayMessage` function calls `L2ETHGateway.finalizeDepositETH` to transfer ETH to the recipient account on L2.
 
 6. If the user calls `depositETHAndCall` on L1, `finalizeDepositETH` in the `L2ETHGateway` contract will forward the additional data to the target L2 contract.
-
-<Aside type="tip" title="Upgrade Notice">
-With the February 2024 Bridge Upgrade, step 3 will change. `L1GatewayRouter` will now bypass `L1ETHGateway` when depositing ETH to improve gas efficiency.
-</Aside>
-
 
 ## Depositing ERC20 Tokens
 

--- a/src/content/docs/en/technology/bridge/deposit-gateways.mdx
+++ b/src/content/docs/en/technology/bridge/deposit-gateways.mdx
@@ -8,7 +8,6 @@ whatsnext: { "Withdraw Gateways": "/technology/bridge/withdraw-gateways/" }
 ---
 
 import ClickToZoom from "../../../../../components/ClickToZoom.astro"
-import Aside from "../../../../../components/Aside.astro"
 import DepositWorkflow from "../_images/deposit.png"
 
 This document describes how users and developers can utilize gateways to deposit tokens from L1 to L2. We provide several gateways for standard tokens and a gateway router on L1, listed in the table below.

--- a/src/content/docs/en/technology/bridge/deposit-gateways.mdx
+++ b/src/content/docs/en/technology/bridge/deposit-gateways.mdx
@@ -8,6 +8,7 @@ whatsnext: { "Withdraw Gateways": "/technology/bridge/withdraw-gateways/" }
 ---
 
 import ClickToZoom from "../../../../../components/ClickToZoom.astro"
+import Aside from "../../../../../components/Aside.astro"
 import DepositWorkflow from "../_images/deposit.png"
 
 This document describes how users and developers can utilize gateways to deposit tokens from L1 to L2. We provide several gateways for standard tokens and a gateway router on L1, listed in the table below.
@@ -21,6 +22,13 @@ This document describes how users and developers can utilize gateways to deposit
 | `L1WETHGateway`          | The gateway for Wrapped ETH deposits.                            |
 | `L1ERC721Gateway`        | The gateway for ERC-721 token deposits.                          |
 | `L1ERC1155Gateway`       | The gateway for ERC-1155 token deposits.                         |
+
+<Aside type="tip" title="Upgrade Notice">
+With the February 2024 Bridge Upgrade, `L1GatewayRouter` will now bypass `L1ETHGateway` when bridging ETH to improve gas efficiency.
+
+The upgrade is expected to be finalized on February 19th, 2024 after a two-week timelock. Scroll Sepolia has already undergone this upgrade. Read more [here](https://scroll.io/blog/to-do-slug).
+
+</Aside>
 
 ## Overview
 
@@ -57,6 +65,11 @@ Scroll treats ETH as its native token. We pre-allocate a sufficient amount of ET
    In the case of ETH deposit, the `relayMessage` function calls `L2ETHGateway.finalizeDepositETH` to transfer ETH to the recipient account on L2.
 
 6. If the user calls `depositETHAndCall` on L1, `finalizeDepositETH` in the `L2ETHGateway` contract will forward the additional data to the target L2 contract.
+
+<Aside type="tip" title="Upgrade Notice">
+With the February 2024 Bridge Upgrade, step 3 will change. `L1GatewayRouter` will now bypass `L1ETHGateway` when depositing ETH to improve gas efficiency.
+</Aside>
+
 
 ## Depositing ERC20 Tokens
 

--- a/src/content/docs/en/technology/bridge/withdraw-gateways.mdx
+++ b/src/content/docs/en/technology/bridge/withdraw-gateways.mdx
@@ -8,6 +8,7 @@ whatsnext: { "Sequencer": "/technology/sequencer/execution-node/" }
 ---
 
 import ClickToZoom from "../../../../../components/ClickToZoom.astro"
+import Aside from "../../../../../components/Aside.astro"
 import WithdrawWorkflow from "../_images/withdraw.png"
 
 This document describes how users and developers can utilize gateways to withdraw tokens from L2 to L1. We provide several gateways for standard tokens and a gateway router on L2, listed in the table below.
@@ -21,6 +22,13 @@ This document describes how users and developers can utilize gateways to withdra
 | `L2WETHGateway`          | The gateway for Wrapped ETH withdrawals.                            |
 | `L2ERC721Gateway`        | The gateway for ERC-721 token withdrawals.                          |
 | `L2ERC1155Gateway`       | The gateway for ERC-1155 token withdrawals.                         |
+
+<Aside type="tip" title="Upgrade Notice">
+With the February 2024 Bridge Upgrade, `L2GatewayRouter` will now bypass `L2ETHGateway` when bridging ETH to improve gas efficiency.
+
+The upgrade is expected to be finalized on February 19th, 2024 after a two-week timelock. Scroll Sepolia has already undergone this upgrade. Read more [here](https://scroll.io/blog/to-do-slug).
+
+</Aside>
 
 ## Overview
 
@@ -53,6 +61,10 @@ The withdrawal of ETH token works as follows.
 3. The withdrawn ETH is again locked in the `L2ScrollMessenger` contract. `L2ScrollMessenger` appends the message to the message queue in the `L2MessageQueue` contract.
 4. The withdrawal execution transaction on L1 calls the `L1ScrollMessenger.relayMessageWithProof` function to finalize the withdrawal. In the case of ETH withdrawal, the `relayMessageWithProof` function calls `L1ETHGateway.finalizeWithdrawETH` to send back ETH to the recipient account on L1.
 5. If the user calls `withdrawETHAndCall` on L2, the `finalizeWithdrawETH` in the `L1ETHGateway` contract will forward the additional data to the target L1 contract.
+
+<Aside type="tip" title="Upgrade Notice">
+With the February 2024 Bridge Upgrade, step 2 will change. `L2GatewayRouter` will now bypass `L2ETHGateway` when depositing ETH to improve gas efficiency.
+</Aside>
 
 ## Withdrawing ERC20 Tokens
 

--- a/src/content/docs/en/technology/bridge/withdraw-gateways.mdx
+++ b/src/content/docs/en/technology/bridge/withdraw-gateways.mdx
@@ -23,13 +23,6 @@ This document describes how users and developers can utilize gateways to withdra
 | `L2ERC721Gateway`        | The gateway for ERC-721 token withdrawals.                          |
 | `L2ERC1155Gateway`       | The gateway for ERC-1155 token withdrawals.                         |
 
-<Aside type="tip" title="Upgrade Notice">
-With the February 2024 Bridge Upgrade, `L2GatewayRouter` will now bypass `L2ETHGateway` when bridging ETH to improve gas efficiency.
-
-The upgrade is expected to be finalized on February 19th, 2024 after a two-week timelock. Scroll Sepolia has already undergone this upgrade. Read more [here](https://scroll.io/blog/to-do-slug).
-
-</Aside>
-
 ## Overview
 
 <ClickToZoom src={WithdrawWorkflow} alt="Withdraw Workflow" />
@@ -61,10 +54,6 @@ The withdrawal of ETH token works as follows.
 3. The withdrawn ETH is again locked in the `L2ScrollMessenger` contract. `L2ScrollMessenger` appends the message to the message queue in the `L2MessageQueue` contract.
 4. The withdrawal execution transaction on L1 calls the `L1ScrollMessenger.relayMessageWithProof` function to finalize the withdrawal. In the case of ETH withdrawal, the `relayMessageWithProof` function calls `L1ETHGateway.finalizeWithdrawETH` to send back ETH to the recipient account on L1.
 5. If the user calls `withdrawETHAndCall` on L2, the `finalizeWithdrawETH` in the `L1ETHGateway` contract will forward the additional data to the target L1 contract.
-
-<Aside type="tip" title="Upgrade Notice">
-With the February 2024 Bridge Upgrade, step 2 will change. `L2GatewayRouter` will now bypass `L2ETHGateway` when depositing ETH to improve gas efficiency.
-</Aside>
 
 ## Withdrawing ERC20 Tokens
 

--- a/src/content/docs/en/technology/overview/scroll-upgrades.mdx
+++ b/src/content/docs/en/technology/overview/scroll-upgrades.mdx
@@ -1,0 +1,98 @@
+---
+section: technology
+date: Last Modified
+title: "Scroll Upgrades"
+lang: "en"
+permalink: "technology/overview/scroll-upgrades"
+---
+
+As the team continues to progress on Scroll's roadmap, we will be upgrading the Scroll network to include new features and improvements.
+
+The following contracts are used to initiate upgrades and execute upgrades after the two-week timelock period:
+
+| Contract         | Network                                                      | Address | 
+| ------------------------ | ------- | - | 
+| L1 Scroll Multisig | Ethereum| [`0xEfc9D1096fb65c832207E5e7F13C2D1102244dbe`](https://etherscan.io/address/0xEfc9D1096fb65c832207E5e7F13C2D1102244dbe)| 
+| L1 Timelock |  Ethereum| [`0x1A658B88fD0a3c82fa1a0609fCDbD32e7dd4aB9C`](https://etherscan.io/address/0x1A658B88fD0a3c82fa1a0609fCDbD32e7dd4aB9C)| 
+| L2 Scroll Multisig | Scroll| [`0xEfc9D1096fb65c832207E5e7F13C2D1102244dbe`](https://scrollscan.com/address/0xEfc9D1096fb65c832207E5e7F13C2D1102244dbe)|
+| L2 Timelock | Scroll | [`0xf6069DB81239E5194bb53f83aF564d282357bc99`](https://scrollscan.com/address/0xf6069DB81239E5194bb53f83aF564d282357bc99)|
+
+## February 2024 Bridge Upgrade
+
+### Overview
+
+To reduce bridging costs, we implemented a number of gas optimizations on our bridge and rollup contract suite. The optimization techniques used include the following:
+
+- We will now use constants to store some companion contract addresses, instead of using storage variables. This is possible since these values should (almost) never change. With this change we can save on a few storage load operations.
+- We updated the intrinsic gas estimation in `L1MessageQueue` to use a simple upper bound instead of an exact calculation. The two results will be similar for most bridge transactions but the new implementation is significantly cheaper.
+- The gateway router contracts will now bridge ETH directly through the messenger contracts, skipping `ETHGateway`.
+- We merged two contracts `L1MessageQueue` and `L2GasPriceOracle` to save on call costs from one contract to the other.
+
+### Timeline
+
+
+- **Scroll Sepolia:**
+	- Network Upgrade: January 19, 2024
+- **Scroll Mainnet:**
+	- Upgrade Initiation: February 5, 2024
+	- Timelock Completion & Upgrade: February 19, 2024
+
+
+### Technical Details
+
+#### Code Changes
+- [Bridge Cost Optimization](https://github.com/scroll-tech/scroll/pull/1011)
+- [Audit Fixes](https://github.com/scroll-tech/scroll/pulls?q=is%3Apr+created%3A%3E2024-01-27+created%3A%3C2024-02-19+state%3Aopen+OZ+)
+- [Previously deployed version](https://github.com/scroll-tech/scroll/tree/ff380141a8cbcc214dc65f17ffa44faf4be646b6) (commit `ff380141a8cbcc214dc65f17ffa44faf4be646b6`)
+- [Version deployed](https://github.com/scroll-tech/scroll/tree/) (commit `TBA`)
+{/* TODO: add commit and link for deployed version */}
+
+#### Audits
+
+- OpenZeppelin
+	- [Initial Report]()
+	- [Final Report]()
+
+{/* TODO: Add links to the audit reports */}
+
+#### List of Changes
+
+**Changes to L1 contracts:**
+
+- In `ScrollChain`, change `messageQueue` and `verifier` to `immutable`.
+- In `L1ScrollMessenger`, change `counterpart`, `rollup`, and `messageQueue` to `immutable`.
+- In all token gateways, change `counterpart`, `router`, and `messenger` to `immutable`.
+- In `L1GatewayRouter`, skip `L1ETHGateway` and bridge directly through `L1ScrollMessenger` for ETH deposits.
+- Merge `L1MessageQueue` and `L2GasPriceOracle` into a single contract `L1MessageQueueWithGasPriceOracle` (deployed on the same address as the previous `L1MessageQueue`). In this contract we also change `messenger` and `scrollChain` to `immutable`, and simplify `calculateIntrinsicGasFee`.
+
+**Changes to L2 contracts:**
+
+- In `L2ScrollMessenger`, change `counterpart` to `immutable`.
+- In all token gateways, change `counterpart`, `router`, and `messenger` to `immutable`.
+- In `L2GatewayRouter`, skip `L2ETHGateway` and bridge directly through `L2ScrollMessenger` for ETH withdrawals.
+
+**Contracts affected:**
+
+- **L1:** `L1MessageQueue`, `L2GasPriceOracle`, `ScrollChain`, `L1WETHGateway`, `L1StandardERC20Gateway`, `L1GatewayRouter`, `L1ScrollMessenger`, `L1CustomERC20Gateway`, `L1ERC721Gateway`, `L1ERC1155Gateway`.
+- **L2:** `L2ScrollMessenger`, `L2WETHGateway`, `L2StandardERC20Gateway`, `L2GatewayRouter`, `L2CustomERC20Gateway`, `L2ERC721Gateway`, `L2ERC1155Gateway`.
+
+#### Compatibility
+
+##### Sequencer and follower nodes (l2geth)
+
+Operators running an `l2geth` node do not need to upgrade. The changes in this upgrade will not affect `l2geth`.
+
+##### Dapps and indexers
+
+Dapps and indexers (and similar off-chain infrastructure) that query contracts or rely on contract interfaces would, in most cases, not need to be changed. The majority of the contract changes are internal and/or backward compatible.
+
+If your application depends on [`L2GasPriceOracle`](https://etherscan.io/address/0x987e300fDfb06093859358522a79098848C33852) to monitor how Scroll keeps track of the L2 gas price on L1, from the upgrade block number you will need to start monitoring [`L1MessageQueueWithGasPriceOracle`](https://etherscan.io/address/0x0d7E906BD9cAFa154b048cFa766Cc1E54E39AF9B).
+
+The original gas price oracle contract will be deprecated: it will no longer be updated or used by the Scroll bridge.
+
+- Ethereum:
+	- `L2GasPriceOracle`: [`0x987e300fDfb06093859358522a79098848C33852`](https://etherscan.io/address/0x987e300fDfb06093859358522a79098848C33852)
+	- `L1MessageQueueWithGasPriceOracle`: [`0x0d7E906BD9cAFa154b048cFa766Cc1E54E39AF9B`](https://etherscan.io/address/0x0d7E906BD9cAFa154b048cFa766Cc1E54E39AF9B)
+- Sepolia:
+	- `L2GasPriceOracle`: [`0x247969F4fad93a33d4826046bc3eAE0D36BdE548`](https://sepolia.etherscan.io/address/0x247969F4fad93a33d4826046bc3eAE0D36BdE548)
+	- `L1MessageQueueWithGasPriceOracle`: [`0xF0B2293F5D834eAe920c6974D50957A1732de763`](https://sepolia.etherscan.io/address/0xF0B2293F5D834eAe920c6974D50957A1732de763)

--- a/src/content/docs/en/technology/overview/scroll-upgrades.mdx
+++ b/src/content/docs/en/technology/overview/scroll-upgrades.mdx
@@ -21,11 +21,10 @@ The following contracts are used to initiate upgrades and execute upgrades after
 
 ### Overview
 
-To reduce bridging costs, we implemented a number of gas optimizations on our bridge and rollup contract suite. The optimization techniques used include the following:
+To reduce bridging costs, we implemented several gas optimizations on our bridge and rollup contract suite. The optimization techniques used include the following:
 
 - We will now use constants to store some companion contract addresses, instead of using storage variables. This is possible since these values should (almost) never change. With this change we can save on a few storage load operations.
 - We updated the intrinsic gas estimation in `L1MessageQueue` to use a simple upper bound instead of an exact calculation. The two results will be similar for most bridge transactions but the new implementation is significantly cheaper.
-- The gateway router contracts will now bridge ETH directly through the messenger contracts, skipping `ETHGateway`.
 - We merged two contracts `L1MessageQueue` and `L2GasPriceOracle` to save on call costs from one contract to the other.
 
 ### Timeline
@@ -34,15 +33,15 @@ To reduce bridging costs, we implemented a number of gas optimizations on our br
 - **Scroll Sepolia:**
 	- Network Upgrade: January 19, 2024
 - **Scroll Mainnet:**
-	- Upgrade Initiation: February 5, 2024
-	- Timelock Completion & Upgrade: February 19, 2024
+	- Upgrade Initiation: February 7, 2024
+	- Timelock Completion & Upgrade: February 21, 2024
 
 
 ### Technical Details
 
 #### Code Changes
 - [Bridge Cost Optimization](https://github.com/scroll-tech/scroll/pull/1011)
-- [Audit Fixes](https://github.com/scroll-tech/scroll/pulls?q=is%3Apr+created%3A%3E2024-01-27+created%3A%3C2024-02-19+state%3Aopen+OZ+)
+- [Audit Fixes](https://github.com/scroll-tech/scroll/pulls?q=OZ+is%3Apr+created%3A2024-01-27..2024-02-10)
 - [Previously deployed version](https://github.com/scroll-tech/scroll/tree/ff380141a8cbcc214dc65f17ffa44faf4be646b6) (commit `ff380141a8cbcc214dc65f17ffa44faf4be646b6`)
 - [Version deployed](https://github.com/scroll-tech/scroll/tree/) (commit `TBA`)
 {/* TODO: add commit and link for deployed version */}
@@ -62,14 +61,12 @@ To reduce bridging costs, we implemented a number of gas optimizations on our br
 - In `ScrollChain`, change `messageQueue` and `verifier` to `immutable`.
 - In `L1ScrollMessenger`, change `counterpart`, `rollup`, and `messageQueue` to `immutable`.
 - In all token gateways, change `counterpart`, `router`, and `messenger` to `immutable`.
-- In `L1GatewayRouter`, skip `L1ETHGateway` and bridge directly through `L1ScrollMessenger` for ETH deposits.
 - Merge `L1MessageQueue` and `L2GasPriceOracle` into a single contract `L1MessageQueueWithGasPriceOracle` (deployed on the same address as the previous `L1MessageQueue`). In this contract we also change `messenger` and `scrollChain` to `immutable`, and simplify `calculateIntrinsicGasFee`.
 
 **Changes to L2 contracts:**
 
 - In `L2ScrollMessenger`, change `counterpart` to `immutable`.
 - In all token gateways, change `counterpart`, `router`, and `messenger` to `immutable`.
-- In `L2GatewayRouter`, skip `L2ETHGateway` and bridge directly through `L2ScrollMessenger` for ETH withdrawals.
 
 **Contracts affected:**
 

--- a/src/content/docs/en/technology/overview/scroll-upgrades.mdx
+++ b/src/content/docs/en/technology/overview/scroll-upgrades.mdx
@@ -43,16 +43,11 @@ To reduce bridging costs, we implemented several gas optimizations on our bridge
 - [Bridge Cost Optimization](https://github.com/scroll-tech/scroll/pull/1011)
 - [Audit Fixes](https://github.com/scroll-tech/scroll/pulls?q=OZ+is%3Apr+created%3A2024-01-27..2024-02-10)
 - [Previously deployed version](https://github.com/scroll-tech/scroll/tree/ff380141a8cbcc214dc65f17ffa44faf4be646b6) (commit `ff380141a8cbcc214dc65f17ffa44faf4be646b6`)
-- [Version deployed](https://github.com/scroll-tech/scroll/tree/) (commit `TBA`)
-{/* TODO: add commit and link for deployed version */}
+- [Version deployed](https://github.com/scroll-tech/scroll/tree/6030927680a92d0285c2c13e6bb27ed27d1f32d1) (commit `6030927680a92d0285c2c13e6bb27ed27d1f32d1`)
 
 #### Audits
 
-- OpenZeppelin
-	- [Initial Report]()
-	- [Final Report]()
-
-{/* TODO: Add links to the audit reports */}
+- [OpenZeppelin](https://blog.openzeppelin.com/scroll-bridge-gas-optimizations-audit)
 
 #### List of Changes
 

--- a/src/content/docs/zh/developers/scroll-contracts.mdx
+++ b/src/content/docs/zh/developers/scroll-contracts.mdx
@@ -45,8 +45,8 @@ import ToggleElement from "../../../../components/ToggleElement.astro"
 
 ### ETH and ERC20 跨链桥
 
-- L1 ERC20 Gateway Router: [`0xF8B1378579659D8F7EE5f3C929c2f3E332E41Fd6`](https://etherscan.io/address/0xF8B1378579659D8F7EE5f3C929c2f3E332E41Fd6)
-- L2 ERC20 Gateway Router: [`0x4C0926FF5252A435FD19e10ED15e5a249Ba19d79`](https://scrollscan.com/address/0x4C0926FF5252A435FD19e10ED15e5a249Ba19d79)
+- L1 Gateway Router: [`0xF8B1378579659D8F7EE5f3C929c2f3E332E41Fd6`](https://etherscan.io/address/0xF8B1378579659D8F7EE5f3C929c2f3E332E41Fd6)
+- L2 Gateway Router: [`0x4C0926FF5252A435FD19e10ED15e5a249Ba19d79`](https://scrollscan.com/address/0x4C0926FF5252A435FD19e10ED15e5a249Ba19d79)
 
 ### 高级跨链桥合约
 
@@ -69,8 +69,10 @@ import ToggleElement from "../../../../components/ToggleElement.astro"
 - ERC1155 Bridge
   - L1 ERC1155 Gateway: [`0xb94f7F6ABcb811c5Ac709dE14E37590fcCd975B6`](https://etherscan.io/address/0xb94f7F6ABcb811c5Ac709dE14E37590fcCd975B6)
   - L2 ERC1155 Gateway: [`0x62597Cc19703aF10B58feF87B0d5D29eFE263bcc`](https://scrollscan.com/address/0x62597Cc19703aF10B58feF87B0d5D29eFE263bcc)
-- Gas Oracle
-  - L2 Gas Oracle (deployed on Mainnet): [`0x987e300fDfb06093859358522a79098848C33852`](https://scrollscan.com/address/0x987e300fDfb06093859358522a79098848C33852)
+- Gas Oracle (deployed on Mainnet)
+  - L2 Gas Oracle (*soon to be deprecated*): [`0x987e300fDfb06093859358522a79098848C33852`](https://etherscan.io/address/0x987e300fDfb06093859358522a79098848C33852)
+  - *after [Feb '24 Bridge Upgrade](https://scroll.io/blog/to-replace-slug)*
+    - L2 Message Queue With Gas Price Oracle: [`0x0d7E906BD9cAFa154b048cFa766Cc1E54E39AF9B`](https://etherscan.io/address/0x0d7E906BD9cAFa154b048cFa766Cc1E54E39AF9B)
 
 ### L2 预部署合约
 
@@ -154,8 +156,8 @@ import ToggleElement from "../../../../components/ToggleElement.astro"
 
 ### ETH and ERC20 跨链桥
 
-- L1 ERC20 Gateway Router: [`0x13FBE0D0e5552b8c9c4AE9e2435F38f37355998a`](https://sepolia.etherscan.io/address/0x13FBE0D0e5552b8c9c4AE9e2435F38f37355998a)
-- L2 ERC20 Gateway Router: [`0x9aD3c5617eCAa556d6E166787A97081907171230`](https://sepolia.scrollscan.com/address/0x9aD3c5617eCAa556d6E166787A97081907171230)
+- L1 Gateway Router: [`0x13FBE0D0e5552b8c9c4AE9e2435F38f37355998a`](https://sepolia.etherscan.io/address/0x13FBE0D0e5552b8c9c4AE9e2435F38f37355998a)
+- L2 Gateway Router: [`0x9aD3c5617eCAa556d6E166787A97081907171230`](https://sepolia.scrollscan.com/address/0x9aD3c5617eCAa556d6E166787A97081907171230)
 
 ### 高级跨链桥合约
 
@@ -178,8 +180,9 @@ import ToggleElement from "../../../../components/ToggleElement.astro"
 - ERC1155 Bridge
   - L1 ERC1155 Gateway: [`0xa5Df8530766A85936EE3E139dECE3bF081c83146`](https://sepolia.etherscan.io/address/0xa5Df8530766A85936EE3E139dECE3bF081c83146)
   - L2 ERC1155 Gateway: [`0xe17C9b9C66FAF07753cdB04316D09f52144612A5`](https://sepolia.scrollscan.com/address/0xe17C9b9C66FAF07753cdB04316D09f52144612A5)
-- Gas Oracle
-  - L2 Gas Oracle (deployed on Sepolia): [`0x247969F4fad93a33d4826046bc3eAE0D36BdE548`](https://sepolia.scrollscan.com/address/0x247969F4fad93a33d4826046bc3eAE0D36BdE548)
+- Gas Oracle (deployed on Sepolia)
+  - L1 Message Queue With Gas Price Oracle: [`0xF0B2293F5D834eAe920c6974D50957A1732de763`](https://sepolia.etherscan.io/address/0xF0B2293F5D834eAe920c6974D50957A1732de763)
+  - L2 Gas Oracle (*deprecated*): [`0x247969F4fad93a33d4826046bc3eAE0D36BdE548`](https://sepolia.etherscan.io/address/0x247969F4fad93a33d4826046bc3eAE0D36BdE548)
 
 #### L2 预部署合约
 

--- a/src/content/docs/zh/developers/scroll-contracts.mdx
+++ b/src/content/docs/zh/developers/scroll-contracts.mdx
@@ -71,7 +71,7 @@ import ToggleElement from "../../../../components/ToggleElement.astro"
   - L2 ERC1155 Gateway: [`0x62597Cc19703aF10B58feF87B0d5D29eFE263bcc`](https://scrollscan.com/address/0x62597Cc19703aF10B58feF87B0d5D29eFE263bcc)
 - Gas Oracle (deployed on Mainnet)
   - L2 Gas Oracle (*soon to be deprecated*): [`0x987e300fDfb06093859358522a79098848C33852`](https://etherscan.io/address/0x987e300fDfb06093859358522a79098848C33852)
-  - *after [Feb '24 Bridge Upgrade](https://scroll.io/blog/to-replace-slug)*
+  - *after [Feb '24 Bridge Upgrade](https://scroll.io/blog/protocol-upgrade-bridging-cost-reduction)*
     - L2 Message Queue With Gas Price Oracle: [`0x0d7E906BD9cAFa154b048cFa766Cc1E54E39AF9B`](https://etherscan.io/address/0x0d7E906BD9cAFa154b048cFa766Cc1E54E39AF9B)
 
 ### L2 预部署合约


### PR DESCRIPTION
Initial updates notifying of Sepolia bridge update and the upcoming mainnet update.

Should not be pushed to prod until the article is published and links are updated.

Additional Follow-ups:
- Revisit Spanish contracts page
- Assess if we need to disable `zh` for prod
- Add method-specific documentation for L2 Gas Oracle methods
- Once live, update graphics, replace notices with fully updated content and deprecation notices where appropriate.