### PR TITLE
Typo fixes in Scroll docs at .../eth-and-erc20-token-bridge.mdx and .../erc1155-token-bridge.mdx

### DIFF
--- a/src/content/docs/en/developers/l1-and-l2-bridging/erc1155-token-bridge.mdx
+++ b/src/content/docs/en/developers/l1-and-l2-bridging/erc1155-token-bridge.mdx
@@ -158,5 +158,5 @@ Update the mapping that connects an ERC1155 token contract from L2 to L1.
 
 | Parameter | Description                                       |
 | --------- | ------------------------------------------------- |
-| \_l1Token | The address of th ERC1155 token in L1.            |
+| \_l1Token | The address of the ERC1155 token in L1.            |
 | \_l2Token | The address of corresponding ERC1155 token in L2. |

--- a/src/content/docs/en/developers/l1-and-l2-bridging/eth-and-erc20-token-bridge.mdx
+++ b/src/content/docs/en/developers/l1-and-l2-bridging/eth-and-erc20-token-bridge.mdx
@@ -33,7 +33,7 @@ All Gateway contracts will form the message and send it to the `L1ScrollMessenge
   address of the `L1ScrollMessenger`. 
 </Aside>
 
-When a new block gets created on L1, the Watcher will detect the message on the `L1MessageQueue` and will pass it to the Relayer service, which will submit the transaction to the L2 via the l2geth node. Finally, the l2geth node will pass the transaction to the `L2ScrollMessagner` contract for execution on L2.
+When a new block gets created on L1, the Watcher will detect the message on the `L1MessageQueue` and will pass it to the Relayer service, which will submit the transaction to the L2 via the l2geth node. Finally, the l2geth node will pass the transaction to the `L2ScrollMessenger` contract for execution on L2.
 
 ## Withdraw ETH and ERC20 tokens from L2
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.Any change needs to be discussed before proceeding.**

## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

closes #191

...

## Description

<!-- Please provide enough information so that others can review your pull request: -->

Fixes typos in Scroll docs lang[en] at:

/scroll-tech/scroll-documentation/src/content/docs/en/developers/l1-and-l2-bridging/eth-and-erc20-token-bridge.mdx
Typo in line 36: "L2ScrollMessagner" instead of "L2ScrollMessenger"

/scroll-tech/scroll-documentation/src/content/docs/en/developers/l1-and-l2-bridging/erc1155-token-bridge.mdx
Typo in line 161: "th" instead of "the"

...

## Changes

<!--Explain the **details** for making this change. What existing problem does the pull request solve? -->

- Fixed the typo .../eth-and-erc20-token-bridge.mdx, where there were a confusion about Scroll L2 Messenger contract's naming.
- Fixed the typo .../erc1155-token-bridge.mdx, it was a minor typo, but it's better to avoid any typos at all
