### PR TITLE
Update eth-and-erc20-token-bridge.mdx

### DIFF
--- a/src/content/docs/en/developers/l1-and-l2-bridging/eth-and-erc20-token-bridge.mdx
+++ b/src/content/docs/en/developers/l1-and-l2-bridging/eth-and-erc20-token-bridge.mdx
@@ -76,7 +76,7 @@ interface IScrollStandardERC20 {
   /// @param _amount The amount of token to mint.
   function mint(address _to, uint256 _amount) external;
 
-  /// @notice Mint some token from account.
+  /// @notice Burn some token from account.
   /// @dev Gateway Utilities, only gateway contract can call
   /// @param _from The address of account to burn token.
   /// @param _amount The amount of token to mint.


### PR DESCRIPTION
Update exactly the description of burn token (not mint)

## Closing issues

closes #[207](https://github.com/scroll-tech/scroll-documentation/issues/207)

## Description

In [ETH and ERC20 Token Bridge ](https://docs.scroll.io/en/developers/l1-and-l2-bridging/eth-and-erc20-token-bridge/) docs, the description of **burn** function is not exactly

## Changes

- Update this is **burn** action (not **mint**)
