### PR TITLE
add zktrie verifier audit

### DIFF
--- a/src/content/docs/en/technology/security/audits-and-bug-bounty.mdx
+++ b/src/content/docs/en/technology/security/audits-and-bug-bounty.mdx
@@ -56,6 +56,10 @@ Scroll has worked with several industry-leading security audit firms to review o
   - [Report 1](https://github.com/Zellic/publications/blob/master/Scroll%20-%2005.26.23%20Zellic%20Audit%20Report.pdf)
   - [Report 2](https://github.com/Zellic/publications/blob/master/Scroll%20-%2009.27.23%20Zellic%20Audit%20Report.pdf)
 
+### Additional contracts
+- ZkTrie Verifier
+  - [OpenZeppelin](https://blog.openzeppelin.com/scroll-zktrieverifier-audit#notes-additional-information)
+
 ## Bug Bounty Program
 
 Scroll has an active [Bug Bounty Program on Immunefi](https://immunefi.com/bounty/scroll/), a leading bug bounty platform. The program is open to the public, and we encourage anyone to participate.

--- a/src/content/docs/en/technology/security/audits-and-bug-bounty.mdx
+++ b/src/content/docs/en/technology/security/audits-and-bug-bounty.mdx
@@ -56,7 +56,7 @@ Scroll has worked with several industry-leading security audit firms to review o
   - [Report 1](https://github.com/Zellic/publications/blob/master/Scroll%20-%2005.26.23%20Zellic%20Audit%20Report.pdf)
   - [Report 2](https://github.com/Zellic/publications/blob/master/Scroll%20-%2009.27.23%20Zellic%20Audit%20Report.pdf)
 
-### Additional contracts
+### Auxiliary contracts
 - ZkTrie Verifier
   - [OpenZeppelin](https://blog.openzeppelin.com/scroll-zktrieverifier-audit#notes-additional-information)
 


### PR DESCRIPTION
Adds `ZkTrieVerifier` audit link.

New section needs to be added to Chinese and Spanish repos. Please suggest translations @Turupawn and @ChuhanJin and I'll I'll make the necessary adjustments.