### PR TITLE
Bernoulli upgrade - Sepolia updates

### DIFF
--- a/src/content/docs/en/developers/ethereum-and-scroll-differences.mdx
+++ b/src/content/docs/en/developers/ethereum-and-scroll-differences.mdx
@@ -33,7 +33,7 @@ For open-source contributors and infrastructure builders, please contact our tea
 
 ## EVM Precompiles
 
-The `SHA2-256` (address `0x2`), `RIPEMD-160` (address `0x3`), and `blake2f` (address `0x9`) precompiles are currently not supported. Calls to these precompiled contracts will revert. We plan to enable these three precompiles in a future hard fork.
+The `RIPEMD-160` (address `0x3`) and `blake2f` (address `0x9`) precompiles are currently not supported. The `SHA2-256` (address `0x2`) is currently supported on Scroll Sepolia, but will soon be supported on Scroll Mainnet. Calls to unsupported precompiled contracts will revert. We plan to enable these precompiles in future hard forks.
 
 The `modexp` precompile is supported but only supports inputs of size less than or equal to 32 bytes (i.e. `u256`).
 

--- a/src/content/docs/en/developers/guides/running-a-scroll-node.mdx
+++ b/src/content/docs/en/developers/guides/running-a-scroll-node.mdx
@@ -16,9 +16,9 @@ For most developers, using [our official RPC endpoint](../developer-quickstart#n
 
 ### Finding the latest version
 
-We recommend using the latest release at https://github.com/scroll-tech/go-ethereum/releases. For Scroll Mainnet, the required version is `scroll-v5.0.0` or higher. If you'd like to keep up with new node releases, go to https://github.com/scroll-tech/go-ethereum, click on **Watch**, **Custom**, and make sure that **Releases** is selected. 
-
-For the remainder of this guide, `VERSION` will denote the version tag. For example, `scroll-v5.1.10`.
+We recommend using the latest release at https://github.com/scroll-tech/go-ethereum/releases. The required version is `scroll-v5.2.0` or higher. If you'd like to keep up with new node releases, go to https://github.com/scroll-tech/go-ethereum, click on **Watch**, **Custom**, and make sure that **Releases** is selected. 
+{/* TODO: update min required version for mainnet after Bernoulli upgrade, also update mainnet genesis info */}
+For the remainder of this guide, `VERSION` will denote the version tag. For example, `scroll-v5.2.0`.
 
 ### Hardware Requirements
 
@@ -288,6 +288,7 @@ enode://dd1ac5433c5c2b04ca3166f4cb726f8ff6d2da83dbc16d9b68b1ea83b7079b371eb16ef4
         "londonBlock": 0,
         "archimedesBlock": 0,
         "shanghaiBlock": 0,
+        "bernoulliBlock": 3747132,
         "clique": {
         "period": 3,
         "epoch": 30000

--- a/src/content/docs/en/technology/chain/differences.mdx
+++ b/src/content/docs/en/technology/chain/differences.mdx
@@ -21,7 +21,7 @@ whatsnext: { "Bridge": "/technology/bridge/cross-domain-messaging/" }
 
 | Address | Name         | Scroll behavior                                                                                 |
 | ------- | ------------ | ----------------------------------------------------------------------------------------------- |
-| `0x02`  | `SHA2-256`   | Currently not supported.                                                                        |
+| `0x02`  | `SHA2-256`   | Supported on Scroll Sepolia, and will soon be supported on Scroll Mainnet.                      |
 | `0x03`  | `RIPEMD-160` | Currently not supported.                                                                        |
 | `0x05`  | `modexp`     | Restrict the input values `B, E, M` to unsigned integers less than $2^{256}$.                   |
 | `0x08`  | `ecPairing`  | The inputs are still multiple of 6 32-byte values, but limit the number of tuples to at most 4. |

--- a/src/content/docs/en/technology/chain/rollup.mdx
+++ b/src/content/docs/en/technology/chain/rollup.mdx
@@ -9,6 +9,8 @@ whatsnext: { "EVM Differences from Ethereum": "/technology/chain/differences/" }
 
 import ClickToZoom from "../../../../../components/ClickToZoom.astro"
 import RollupProcess from "../_images/rollup.png"
+import NetworkTabs from "../../../../../components/Tabs/NetworkTabs.astro"
+import { Tabs } from "../../../../../components/Tabs/Tabs.tsx"
 
 This document describes the rollup process in Scroll.
 
@@ -119,37 +121,78 @@ At this stage, the state root of the latest finalized batch can be used trustles
 
 This section describes the codec of three data structures in the Rollup contract: `BatchHeader`, `Chunk`, and `BlockContext`.
 
-### `BatchHeader` Codec
+<NetworkTabs>
+    <Fragment slot="Mainnet">
+        ### `BatchHeader` Codec
 
-| Field                    | Bytes   | Type        | Offset | Description                                                     |
-| ------------------------ | ------- | ----------- | ------ | --------------------------------------------------------------- |
-| `version`                | 1       | `uint8`     | 0      | The batch header version                                        |
-| `batchIndex`             | 8       | `uint64`    | 1      | The index of the batch                                          |
-| `l1MessagePopped`        | 8       | `uint64`    | 9      | The number of L1 messages poped in the batch                    |
-| `totalL1MessagePopped`   | 8       | `uint64`    | 17     | The number of total L1 messages popped after the batch          |
-| `dataHash`               | 32      | `bytes32`   | 25     | The data hash of the batch                                      |
-| `blobVersionedHash`      | 32      | `bytes32`   | 57     | The versioned hash of the blob with this batch’s data           |
-| `parentBatchHash`        | 32      | `bytes32`   | 89     | The parent batch hash                                           |
-| `skippedL1MessageBitmap` | dynamic | `uint256[]` | 121    | A bitmap to indicate which L1 messages are skipped in the batch |
+        | Field                    | Bytes   | Type        | Offset | Description                                                     |
+        | ------------------------ | ------- | ----------- | ------ | --------------------------------------------------------------- |
+        | `version`                | 1       | `uint8`     | 0      | The batch header version                                        |
+        | `batchIndex`             | 8       | `uint64`    | 1      | The index of the batch                                          |
+        | `l1MessagePopped`        | 8       | `uint64`    | 9      | The number of L1 messages poped in the batch                    |
+        | `totalL1MessagePopped`   | 8       | `uint64`    | 17     | The number of total L1 messages popped after the batch          |
+        | `dataHash`               | 32      | `bytes32`   | 25     | The data hash of the batch                                      |
+        | `parentBatchHash`        | 32      | `bytes32`   | 57     | The parent batch hash                                           |
+        | `skippedL1MessageBitmap` | dynamic | `uint256[]` | 89     | A bitmap to indicate which L1 messages are skipped in the batch |
 
-### `Chunk` Codec
+        ### `Chunk` Codec
 
-| Field            | Bytes   | Type           | Offset    | Description                                                                                                                                       |
-| ---------------- | ------- | -------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `numBlocks`      | 1       | `uint8`        | 0         | The number of blocks in the chunk                                                                                                                 |
-| `block[0]`       | 60      | `BlockContext` | 1         | The block information of the 1st block                                                                                                            |
-| ...              | ...     | ...            | ...       | ...                                                                                                                                               |
-| `block[i]`       | 60      | `BlockContext` | `60*i+1`  | The block information of `i+1`-th block                                                                                                           |
-| ...              | ...     | ...            | ...       | ...                                                                                                                                               |
-| `block[n-1]`     | 60      | `BlockContext` | `60*n-59` | The block information of the last block                                                                                                           |
+        | Field            | Bytes   | Type           | Offset    | Description                                                                                                                                       |
+        | ---------------- | ------- | -------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+        | `numBlocks`      | 1       | `uint8`        | 0         | The number of blocks in the chunk                                                                                                                 |
+        | `block[0]`       | 60      | `BlockContext` | 1         | The block information of the 1st block                                                                                                            |
+        | ...              | ...     | ...            | ...       | ...                                                                                                                                               |
+        | `block[i]`       | 60      | `BlockContext` | `60*i+1`  | The block information of `i+1`-th block                                                                                                           |
+        | ...              | ...     | ...            | ...       | ...                                                                                                                                               |
+        | `block[n-1]`     | 60      | `BlockContext` | `60*n-59` | The block information of the last block  
+        | `l2Transactions` | dynamic | `bytes`        | `60*n+1`  | The concatenated RLP encoding of L2 transactions with signatures. The byte length (`uint32`) of RLP encoding is inserted before each transaction. |                                                                                                         |
 
-### `BlockContext` Codec
+        ### `BlockContext` Codec
 
-| Field             | Bytes | Type      | Offset | Description                                                                         |
-| ----------------- | ----- | --------- | ------ | ----------------------------------------------------------------------------------- |
-| `blockNumber`     | 8     | `uint64`  | 0      | The block number                                                                    |
-| `timestamp`       | 8     | `uint64`  | 8      | The block time                                                                      |
-| `baseFee`         | 32    | `uint256` | 16     | The base fee of this block. Currently, it is always 0, because we disable EIP-1559. |
-| `gasLimit`        | 8     | `uint64`  | 48     | The gas limit of this block                                                         |
-| `numTransactions` | 2     | `uint16`  | 56     | The number of transactions in this block, including both L1 & L2 txs                |
-| `numL1Messages`   | 2     | `uint16`  | 58     | The number of L1 messages in this block                                             |
+        | Field             | Bytes | Type      | Offset | Description                                                                         |
+        | ----------------- | ----- | --------- | ------ | ----------------------------------------------------------------------------------- |
+        | `blockNumber`     | 8     | `uint64`  | 0      | The block number                                                                    |
+        | `timestamp`       | 8     | `uint64`  | 8      | The block time                                                                      |
+        | `baseFee`         | 32    | `uint256` | 16     | The base fee of this block. Currently, it is always 0, because we disable EIP-1559. |
+        | `gasLimit`        | 8     | `uint64`  | 48     | The gas limit of this block                                                         |
+        | `numTransactions` | 2     | `uint16`  | 56     | The number of transactions in this block, including both L1 & L2 txs                |
+        | `numL1Messages`   | 2     | `uint16`  | 58     | The number of L1 messages in this block    
+    </Fragment>
+    <Fragment slot="Sepolia">
+        ### `BatchHeader` Codec
+
+        | Field                    | Bytes   | Type        | Offset | Description                                                     |
+        | ------------------------ | ------- | ----------- | ------ | --------------------------------------------------------------- |
+        | `version`                | 1       | `uint8`     | 0      | The batch header version                                        |
+        | `batchIndex`             | 8       | `uint64`    | 1      | The index of the batch                                          |
+        | `l1MessagePopped`        | 8       | `uint64`    | 9      | The number of L1 messages poped in the batch                    |
+        | `totalL1MessagePopped`   | 8       | `uint64`    | 17     | The number of total L1 messages popped after the batch          |
+        | `dataHash`               | 32      | `bytes32`   | 25     | The data hash of the batch                                      |
+        | `blobVersionedHash`      | 32      | `bytes32`   | 57     | The versioned hash of the blob with this batch’s data           |
+        | `parentBatchHash`        | 32      | `bytes32`   | 89     | The parent batch hash                                           |
+        | `skippedL1MessageBitmap` | dynamic | `uint256[]` | 121    | A bitmap to indicate which L1 messages are skipped in the batch |
+
+        ### `Chunk` Codec
+
+        | Field            | Bytes   | Type           | Offset    | Description                                                                                                                                       |
+        | ---------------- | ------- | -------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+        | `numBlocks`      | 1       | `uint8`        | 0         | The number of blocks in the chunk                                                                                                                 |
+        | `block[0]`       | 60      | `BlockContext` | 1         | The block information of the 1st block                                                                                                            |
+        | ...              | ...     | ...            | ...       | ...                                                                                                                                               |
+        | `block[i]`       | 60      | `BlockContext` | `60*i+1`  | The block information of `i+1`-th block                                                                                                           |
+        | ...              | ...     | ...            | ...       | ...                                                                                                                                               |
+        | `block[n-1]`     | 60      | `BlockContext` | `60*n-59` | The block information of the last block                                                                                                           |
+
+        ### `BlockContext` Codec
+
+        | Field             | Bytes | Type      | Offset | Description                                                                         |
+        | ----------------- | ----- | --------- | ------ | ----------------------------------------------------------------------------------- |
+        | `blockNumber`     | 8     | `uint64`  | 0      | The block number                                                                    |
+        | `timestamp`       | 8     | `uint64`  | 8      | The block time                                                                      |
+        | `baseFee`         | 32    | `uint256` | 16     | The base fee of this block. Currently, it is always 0, because we disable EIP-1559. |
+        | `gasLimit`        | 8     | `uint64`  | 48     | The gas limit of this block                                                         |
+        | `numTransactions` | 2     | `uint16`  | 56     | The number of transactions in this block, including both L1 & L2 txs                |
+        | `numL1Messages`   | 2     | `uint16`  | 58     | The number of L1 messages in this block    
+    </Fragment>
+</NetworkTabs>
+

--- a/src/content/docs/en/technology/chain/rollup.mdx
+++ b/src/content/docs/en/technology/chain/rollup.mdx
@@ -128,8 +128,9 @@ This section describes the codec of three data structures in the Rollup contract
 | `l1MessagePopped`        | 8       | `uint64`    | 9      | The number of L1 messages poped in the batch                    |
 | `totalL1MessagePopped`   | 8       | `uint64`    | 17     | The number of total L1 messages popped after the batch          |
 | `dataHash`               | 32      | `bytes32`   | 25     | The data hash of the batch                                      |
-| `parentBatchHash`        | 32      | `bytes32`   | 57     | The parent batch hash                                           |
-| `skippedL1MessageBitmap` | dynamic | `uint256[]` | 89     | A bitmap to indicate which L1 messages are skipped in the batch |
+| `blobVersionedHash`      | 32      | `bytes32`   | 57     | The versioned hash of the blob with this batch’s data           |
+| `parentBatchHash`        | 32      | `bytes32`   | 89     | The parent batch hash                                           |
+| `skippedL1MessageBitmap` | dynamic | `uint256[]` | 121    | A bitmap to indicate which L1 messages are skipped in the batch |
 
 ### `Chunk` Codec
 
@@ -141,7 +142,6 @@ This section describes the codec of three data structures in the Rollup contract
 | `block[i]`       | 60      | `BlockContext` | `60*i+1`  | The block information of `i+1`-th block                                                                                                           |
 | ...              | ...     | ...            | ...       | ...                                                                                                                                               |
 | `block[n-1]`     | 60      | `BlockContext` | `60*n-59` | The block information of the last block                                                                                                           |
-| `l2Transactions` | dynamic | `bytes`        | `60*n+1`  | The concatenated RLP encoding of L2 transactions with signatures. The byte length (`uint32`) of RLP encoding is inserted before each transaction. |
 
 ### `BlockContext` Codec
 

--- a/src/content/docs/en/technology/chain/rollup.mdx
+++ b/src/content/docs/en/technology/chain/rollup.mdx
@@ -121,9 +121,8 @@ At this stage, the state root of the latest finalized batch can be used trustles
 
 This section describes the codec of three data structures in the Rollup contract: `BatchHeader`, `Chunk`, and `BlockContext`.
 
-<NetworkTabs>
-    <Fragment slot="Mainnet">
-        ### `BatchHeader` Codec
+### Scroll Mainnet 
+        #### `BatchHeader` Codec
 
         | Field                    | Bytes   | Type        | Offset | Description                                                     |
         | ------------------------ | ------- | ----------- | ------ | --------------------------------------------------------------- |
@@ -135,7 +134,7 @@ This section describes the codec of three data structures in the Rollup contract
         | `parentBatchHash`        | 32      | `bytes32`   | 57     | The parent batch hash                                           |
         | `skippedL1MessageBitmap` | dynamic | `uint256[]` | 89     | A bitmap to indicate which L1 messages are skipped in the batch |
 
-        ### `Chunk` Codec
+        #### `Chunk` Codec
 
         | Field            | Bytes   | Type           | Offset    | Description                                                                                                                                       |
         | ---------------- | ------- | -------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -147,7 +146,7 @@ This section describes the codec of three data structures in the Rollup contract
         | `block[n-1]`     | 60      | `BlockContext` | `60*n-59` | The block information of the last block  
         | `l2Transactions` | dynamic | `bytes`        | `60*n+1`  | The concatenated RLP encoding of L2 transactions with signatures. The byte length (`uint32`) of RLP encoding is inserted before each transaction. |                                                                                                         |
 
-        ### `BlockContext` Codec
+        #### `BlockContext` Codec
 
         | Field             | Bytes | Type      | Offset | Description                                                                         |
         | ----------------- | ----- | --------- | ------ | ----------------------------------------------------------------------------------- |
@@ -157,9 +156,10 @@ This section describes the codec of three data structures in the Rollup contract
         | `gasLimit`        | 8     | `uint64`  | 48     | The gas limit of this block                                                         |
         | `numTransactions` | 2     | `uint16`  | 56     | The number of transactions in this block, including both L1 & L2 txs                |
         | `numL1Messages`   | 2     | `uint16`  | 58     | The number of L1 messages in this block    
-    </Fragment>
-    <Fragment slot="Sepolia">
-        ### `BatchHeader` Codec
+
+### Scroll Sepolia 
+
+        #### `BatchHeader` Codec
 
         | Field                    | Bytes   | Type        | Offset | Description                                                     |
         | ------------------------ | ------- | ----------- | ------ | --------------------------------------------------------------- |
@@ -172,7 +172,7 @@ This section describes the codec of three data structures in the Rollup contract
         | `parentBatchHash`        | 32      | `bytes32`   | 89     | The parent batch hash                                           |
         | `skippedL1MessageBitmap` | dynamic | `uint256[]` | 121    | A bitmap to indicate which L1 messages are skipped in the batch |
 
-        ### `Chunk` Codec
+        #### `Chunk` Codec
 
         | Field            | Bytes   | Type           | Offset    | Description                                                                                                                                       |
         | ---------------- | ------- | -------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -183,7 +183,7 @@ This section describes the codec of three data structures in the Rollup contract
         | ...              | ...     | ...            | ...       | ...                                                                                                                                               |
         | `block[n-1]`     | 60      | `BlockContext` | `60*n-59` | The block information of the last block                                                                                                           |
 
-        ### `BlockContext` Codec
+        #### `BlockContext` Codec
 
         | Field             | Bytes | Type      | Offset | Description                                                                         |
         | ----------------- | ----- | --------- | ------ | ----------------------------------------------------------------------------------- |
@@ -193,6 +193,5 @@ This section describes the codec of three data structures in the Rollup contract
         | `gasLimit`        | 8     | `uint64`  | 48     | The gas limit of this block                                                         |
         | `numTransactions` | 2     | `uint16`  | 56     | The number of transactions in this block, including both L1 & L2 txs                |
         | `numL1Messages`   | 2     | `uint16`  | 58     | The number of L1 messages in this block    
-    </Fragment>
-</NetworkTabs>
+
 

--- a/src/content/docs/en/technology/overview/scroll-upgrades.mdx
+++ b/src/content/docs/en/technology/overview/scroll-upgrades.mdx
@@ -17,6 +17,8 @@ The following contracts are used to initiate upgrades and execute upgrades after
 | L2 Scroll Multisig | Scroll| [`0xEfc9D1096fb65c832207E5e7F13C2D1102244dbe`](https://scrollscan.com/address/0xEfc9D1096fb65c832207E5e7F13C2D1102244dbe)|
 | L2 Timelock | Scroll | [`0xf6069DB81239E5194bb53f83aF564d282357bc99`](https://scrollscan.com/address/0xf6069DB81239E5194bb53f83aF564d282357bc99)|
 
+You can join our [Telegram channel for technical updates](https://t.me/scroll_tech_updates), which includes future upgrade announcements and on-chain operation events.
+
 ## Bernoulli Upgrade
 
 ### Overview
@@ -26,7 +28,7 @@ This upgrade features a significant reduction in transaction costs by introducin
 ### Timeline
 
 - **Scroll Sepolia**
-	- Network Upgrade: April 24th, 2024
+	- Network Upgrade: April 15th, 2024
 - **Scroll Mainnet**
 	- TBD
 

--- a/src/content/docs/en/technology/overview/scroll-upgrades.mdx
+++ b/src/content/docs/en/technology/overview/scroll-upgrades.mdx
@@ -17,6 +17,58 @@ The following contracts are used to initiate upgrades and execute upgrades after
 | L2 Scroll Multisig | Scroll| [`0xEfc9D1096fb65c832207E5e7F13C2D1102244dbe`](https://scrollscan.com/address/0xEfc9D1096fb65c832207E5e7F13C2D1102244dbe)|
 | L2 Timelock | Scroll | [`0xf6069DB81239E5194bb53f83aF564d282357bc99`](https://scrollscan.com/address/0xf6069DB81239E5194bb53f83aF564d282357bc99)|
 
+## Apr 2024 Bernoulli Upgrade
+
+### Overview
+
+This upgrade features a significant reduction in transaction costs by introducing support for EIP-4844 data blobs and supporting the SHA2-256 precompile. 
+
+### Timeline
+
+- **Scroll Sepolia**
+	- Network Upgrade: April 24th, 2024
+- **Scroll Mainnet**
+	- TBD
+
+### Technical Details
+
+#### Contract changes
+
+The contract changes for this upgrade are in [this PR](https://github.com/scroll-tech/scroll/pull/1179).
+
+As well as the audit fixes listed here [TODO]
+
+#### Node changes
+
+The new node version is v5.2.0. See [here](https://github.com/scroll-tech/go-ethereum/releases/tag/scroll-v5.2.0) for the changelog.
+
+#### Prover changes
+
+[TODO]
+
+#### Audits
+
+- OpenZeppelin [TODO]
+- TrailofBits [TODO]
+
+### Compatibility
+
+#### Sequencer and follower nodes (l2geth)
+
+This upgrade is a hard fork as it introduces the new blob data type and the SHA2-256 precompiled contract. Operators running an `l2geth` node are required to upgrade before the hard fork block. See the [node releases](https://github.com/scroll-tech/go-ethereum/releases) for more information.
+
+#### Indexers and Bridges
+
+This upgrade changes the format that Scroll uses to publish data to Ethereum. Projects that rely on this data should carefully review [the new data format](https://docs.scroll.io/en/technology/chain/rollup/#codec), and check whether their decoders need to be adjusted. A summary of the new format:
+
+- The format of [`BlockContext`](https://github.com/scroll-tech/scroll/blob/5362e28f744093495c1c09a6b68fc96a3264278b/common/types/encoding/codecv1/codecv1.go#L125) will not change.
+- `Chunks` will [no longer include](https://github.com/scroll-tech/scroll/blob/5362e28f744093495c1c09a6b68fc96a3264278b/common/types/encoding/codecv1/codecv1.go#L162) the L2 transaction data. This will instead be [stored in a blob](https://github.com/scroll-tech/scroll/blob/5362e28f744093495c1c09a6b68fc96a3264278b/common/types/encoding/codecv1/codecv1.go#L284) attached to the `commitBatch` transaction.
+- `BatchHeader` now contains one new field, [`BlobVersionedHash`](https://github.com/scroll-tech/scroll/blob/5362e28f744093495c1c09a6b68fc96a3264278b/common/types/encoding/codecv1/codecv1.go#L405). 
+
+#### Provers
+
+This upgrade involves a breaking change in zkevm-circuits. Operators running a prover node are required to upgrade.
+
 ## February 2024 Bridge Upgrade
 
 ### Overview

--- a/src/content/docs/en/technology/overview/scroll-upgrades.mdx
+++ b/src/content/docs/en/technology/overview/scroll-upgrades.mdx
@@ -17,7 +17,7 @@ The following contracts are used to initiate upgrades and execute upgrades after
 | L2 Scroll Multisig | Scroll| [`0xEfc9D1096fb65c832207E5e7F13C2D1102244dbe`](https://scrollscan.com/address/0xEfc9D1096fb65c832207E5e7F13C2D1102244dbe)|
 | L2 Timelock | Scroll | [`0xf6069DB81239E5194bb53f83aF564d282357bc99`](https://scrollscan.com/address/0xf6069DB81239E5194bb53f83aF564d282357bc99)|
 
-## Apr 2024 Bernoulli Upgrade
+## Bernoulli Upgrade
 
 ### Overview
 
@@ -67,9 +67,9 @@ This upgrade changes the format that Scroll uses to publish data to Ethereum. Pr
 
 #### Provers
 
-This upgrade involves a breaking change in zkevm-circuits. Operators running a prover node are required to upgrade.
+This upgrade involves a breaking change in [zkevm-circuits](https://github.com/scroll-tech/zkevm-circuits). Operators running a prover node are required to upgrade.
 
-## February 2024 Bridge Upgrade
+## Bridge Upgrade
 
 ### Overview
 

--- a/src/content/docs/en/technology/overview/scroll-upgrades.mdx
+++ b/src/content/docs/en/technology/overview/scroll-upgrades.mdx
@@ -36,20 +36,20 @@ This upgrade features a significant reduction in transaction costs by introducin
 
 The contract changes for this upgrade are in [this PR](https://github.com/scroll-tech/scroll/pull/1179).
 
-As well as the audit fixes listed here [TODO]
+{/* As well as the audit fixes listed here [TODO] */}
 
 #### Node changes
 
 The new node version is v5.2.0. See [here](https://github.com/scroll-tech/go-ethereum/releases/tag/scroll-v5.2.0) for the changelog.
 
-#### Prover changes
+{/* #### Prover changes
 
 [TODO]
 
 #### Audits
 
 - OpenZeppelin [TODO]
-- TrailofBits [TODO]
+- TrailofBits [TODO] */}
 
 ### Compatibility
 


### PR DESCRIPTION
These changes should go live after Bernoulli upgrade on Scroll Sepolia

- update Scroll Upgrades page
- update l2geth version and genesis file
- update `BatchHeader` codec
- state sha256 precompile available on Scroll Sepolia