### PR TITLE
fix: Running a Scroll node link

### DIFF
--- a/src/content/docs/en/developers/guides/running-a-scroll-node.mdx
+++ b/src/content/docs/en/developers/guides/running-a-scroll-node.mdx
@@ -4,13 +4,13 @@ date: Last Modified
 title: "Running a Scroll L2geth Node"
 lang: "en"
 permalink: "developers/guides/running-a-scroll-node"
-excerpt: "This guide contains instructions on how to to run your own node on the Scroll network."
+excerpt: "This guide contains instructions on how to run your own node on the Scroll network."
 ---
 
 import Aside from "../../../../../components/Aside.astro"
 import ToggleElement from "../../../../../components/ToggleElement.astro"
 
-For most developers, using [our official RPC endpoint](../developer-quickstart#network-configuration) or one offered by other RPC providers in the ecosystem is the easiest way to get started on Scroll. For those looking to maintain their own node, this guide provides instructions on how to run a "follower node" that participates in the public mempool of transactions, but does not participate in consensus or block building. Scroll nodes are a fork of geth, using the clique protocol for consensus, which we call l2geth.
+For most developers, using [our official RPC endpoint](/en/developers/developer-quickstart#network-configuration) or one offered by other RPC providers in the ecosystem is the easiest way to get started on Scroll. For those looking to maintain their own node, this guide provides instructions on how to run a "follower node" that participates in the public mempool of transactions, but does not participate in consensus or block building. Scroll nodes are a fork of geth, using the clique protocol for consensus, which we call l2geth.
 
 ## Prerequisites
 


### PR DESCRIPTION
Changes relative link, which breaks in prod where '/' is appended to URLs.