### PR TITLE
Remove error in text

### DIFF
--- a/src/content/docs/en/technology/index.mdx
+++ b/src/content/docs/en/technology/index.mdx
@@ -20,5 +20,3 @@ As illustrated in the figure above, Scroll chain consists of three layers:
 - **Proving Layer**: consists of a pool of provers that are responsible for generating the zkEVM validity proofs that verify the correctness of L2 transactions, and a coordinator that dispatches the proving tasks to provers and relays the proofs to the Rollup Node to finalize on Ethereum.
 
 This section of the documentation provides comprehensive information on the Scroll protocol specification, bridging protocol, sequencer, and zkEVM circuit.
-
-*In the remainder of this section, L1 will refer to Ethereum, while L2 will refer to Scroll.*


### PR DESCRIPTION
## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

closes #242

...

## Description


This following sentence is unnecessary and confusing for the reader.

"In the remainder of this section, L1 will refer to Ethereum, while L2 will refer to Scroll.*

The section ends immediately after this statement, it makes no sense.

...

## Changes

Removal of following sentence.

"In the remainder of this section, L1 will refer to Ethereum, while L2 will refer to Scroll.*


