### PR TITLE
Curie: update libzkp version to v0.11.3

### DIFF
--- a/src/content/docs/en/technology/overview/scroll-upgrades.mdx
+++ b/src/content/docs/en/technology/overview/scroll-upgrades.mdx
@@ -62,7 +62,7 @@ The new node version is `v5.4.2`. See the [release notes](https://github.com/scr
 
 #### zkEVM circuit changes
 
-The new version of zkevm circuits is `v0.11.0`. See [here](https://github.com/scroll-tech/zkevm-circuits/releases/tag/v0.11.0) for the release log.
+The new version of zkevm circuits is `v0.11.3`. See [here](https://github.com/scroll-tech/zkevm-circuits/releases/tag/v0.11.3) for the release log.
 
 #### Audits
 


### PR DESCRIPTION
Changed according to [this doc](https://www.notion.so/scrollzkp/Upgrade-3-Curie-blog-post-086e242e49434e04bb23c2ca1d28bd91?pvs=4).

related thread: https://github.com/scroll-tech/scroll-documentation/pull/271#discussion_r1644872807

