### PR TITLE
fix page zktrie: change the domain of nodeKey hashing to 512 instead of 256

### DIFF
--- a/src/content/docs/en/technology/sequencer/zktrie.mdx
+++ b/src/content/docs/en/technology/sequencer/zktrie.mdx
@@ -106,7 +106,7 @@ An Ethereum Account Leaf Node consists of an Ethereum address and a state accoun
 var address byte[20] // 20 bytes in big-endian
 valHi := address[0:16]
 valLo := address[16:20] * 2^96 // padding 12 bytes of 0 at the end
-nodeKey := h{256}(valHi, valLo)
+nodeKey := h{512}(valHi, valLo)
 ```
 
 A state account struct in the Scroll consists of the following fields (`Fr` indicates the finite field and is a 254-bit value)
@@ -182,7 +182,7 @@ A Storage Leaf Node encodes a key-value pair where both key and value are `u256`
 var storageKey byte[32]  // 32 bytes in big-endian
 valHi := storageKey[0:16]
 valLo := storageKey[16:32]
-nodeKey := h{256}(valHi, valLo)
+nodeKey := h{512}(valHi, valLo)
 ```
 
 The storage value is a `u256` value. The `flag` for the storage value is 1, shown below.


### PR DESCRIPTION


## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

closes #281


## Description

The docs states the domain used in creating the nodeKey is 256 but its actually 512.

In the zktrie repo nodekeys are hashed with ToSecureKey() in type/util.go.
ToSecureKey() uses Hash()  in types/bytes32.go which uses HASH_DOMAIN_BYTE32 as domain which is 256 *2 (=512).

ToSecureKey: https://github.com/scroll-tech/zktrie/blob/23181f209e94137f74337b150179aeb80c72e7c8/types/util.go#L107
HASH_DOMAIN_BYTES32: https://github.com/scroll-tech/zktrie/blob/23181f209e94137f74337b150179aeb80c72e7c8/types/hash.go#L16

Am also making a storage prover and here is where i did my test in noir :D (account leaf is lower in same file).
https://github.com/jimjimvalkema/scrollZkStorageProofs/blob/bcdd922405e046e99787b8b47f374befac170779/ScrollStorageProver/src/main.nr#L168

...

## Changes
Changed domain value for the nodeKey mentioned in account leaf and storage leaf section.
Changed the domain from 256 to 512
<!--Explain the **details** for making this change. What existing problem does the pull request solve? -->
