### PR TITLE
Rename confirmed to pre-confirmed for L2

### DIFF
--- a/src/content/docs/en/technology/chain/transactions.mdx
+++ b/src/content/docs/en/technology/chain/transactions.mdx
@@ -50,7 +50,7 @@ Two noticeable behaviors of the `L1MessageTx` transactions:
 
 The transaction life cycle in the Scroll contains the following three phases:
 
-1. **Confirmed**: Users submits a transaction to either the L1 bridge contract or L2 sequencer. The transaction becomes `Confirmed` after it gets executed and included in an L2 block.
+1. **Pre-Confirmed**: Users submits a transaction to either the L1 bridge contract or L2 sequencer. The transaction becomes `Pre-Confirmed` after it gets executed and included in an L2 block.
 2. **Committed**: The transactions are included in a batch and a _commit transaction_ that contains the data of this batch is submitted to L1. After the commit transaction is finalized in the L1 blocks, the transactions in this batch become `Committed`.
 3. **Finalized**: The validity proof of this batch is generated and verified on the L1. After the _finalize transaction_ is finalized on L1, the status of the transaction is `Finalized` and becomes a canonical part of the Scroll L2 chain.
 
@@ -66,7 +66,7 @@ Second, deposit and enforced transactions are originated on L1. Scroll L1 bridge
 - The `L1ScrollMessenger` contract allows users and contracts to send arbitrary messages to L2. See more details in the [Sending Arbitrary Messages](/technology/bridge/cross-domain-messaging#sending-arbitrary-messages).
 - The `EnforcedTxGateway` contract allows EOAs to initiate an enforced transaction from the same address to withdraw tokens or call other contracts on L2. See more details in the [Sending Enforced Transaction](/technology/bridge/cross-domain-messaging#sending-enforced-transactions).
 
-The Scroll sequencer periodically starts a new mining job. It pulls the L1 messages from the `L1MessageQueue` contract and transactions in the L2 mempool and seals a block. Once a transaction is included in a L2 block, its status becomes `Confirmed`.
+The Scroll sequencer periodically starts a new mining job. It pulls the L1 messages from the `L1MessageQueue` contract and transactions in the L2 mempool and seals a block. Once a transaction is included in a L2 block, its status becomes `Pre-Confirmed`.
 
 ### Commit Transaction Data
 

--- a/src/content/docs/en/user-guide/bridge.mdx
+++ b/src/content/docs/en/user-guide/bridge.mdx
@@ -107,11 +107,11 @@ The rollup status `Finalized` indicates that the correct execution of transactio
 
 {/* <ClickToZoom src={bridge6} /> */}
 
-{/* It will open the _Transaction Details_ page in a new tab. You can see this transaction is confirmed on L2. */}
+{/* It will open the _Transaction Details_ page in a new tab. You can see this transaction is pre-confirmed on L2. */}
 
 {/* <ClickToZoom src={bridge7} /> */}
 
-{/* The transaction is confirmed on L2, but still needs to be finalized on Goerli. */}
+{/* The transaction is pre-confirmed on L2, but still needs to be finalized on Goerli. */}
 
 {/* 1. Go back to the [Bridge](https://scroll.io/bridge) app. It takes about 10 minutes before the token shows up in your Goerli wallet. Once your transaction status shows success on L2, you should see the funds in your Goerli wallet and a transaction hash: */}
 

--- a/src/content/docs/es/technology/chain/transactions.mdx
+++ b/src/content/docs/es/technology/chain/transactions.mdx
@@ -50,7 +50,7 @@ Dos comportamientos notables de las transacciones `L1MessageTx`:
 
 El ciclo de vida de la transacción en Scroll contiene las tres fases:
 
-1. **Confirmed**: El usuario envía una transacción al contrato bridge en L1 o al secuenciador en L2. La transacción se convierte en `Confirmed` después de ser ejecutada e incluida en un bloque en L2.
+1. **Pre-Confirmed**: El usuario envía una transacción al contrato bridge en L1 o al secuenciador en L2. La transacción se convierte en `Confirmed` después de ser ejecutada e incluida en un bloque en L2.
 2. **Committed**: Las transacciones se incluyen en un lote y se envía a L1 una _commit transaction_ que contiene los datos de este lote. Después de que la commit transaction se finaliza en los bloques L1, las transacciones de este lote se convierten en `Committed`.
 3. **Finalized**: La prueba de validez de este lote se genera y verifica en el L1. Después de que la _finalize transaction_ se termina en el L1, el estado de la transacción es `Finalized` y se convierte en una parte canónica de la Scroll L2 chain.
 
@@ -66,7 +66,7 @@ En segundo lugar, las transacciones de depósito y ejecución originadas en L1. 
 - El contrato `L1ScrollMessenger` permite a los usuarios y contratos enviar mensajes arbitrarios a L2. Ver más detalles en [Envío de Mensajes Arbitrarios](/es/technology/bridge/cross-domain-messaging#envío-de-mensajes-arbitrarios).
 - El contrato `EnforcedTxGateway` permite a los EOA iniciar una transacción forzada desde la misma dirección para retirar tokens o llamar a otros contratos en L2. Ver más detalles en [Envío de Transacciones Forzadas](/es/technology/bridge/cross-domain-messaging#envío-de-transacciones-forzadas).
 
-El secuenciador de Scroll inicia periódicamente un nuevo trabajo de minería. Extrae los mensajes L1 del contrato `L1MessageQueue` y las transacciones en el mempool de L2 y sella un bloque. Una vez que una transacción se incluye en un bloque L2, su estado pasa a ser `Confirmed`.
+El secuenciador de Scroll inicia periódicamente un nuevo trabajo de minería. Extrae los mensajes L1 del contrato `L1MessageQueue` y las transacciones en el mempool de L2 y sella un bloque. Una vez que una transacción se incluye en un bloque L2, su estado pasa a ser `Pre-Confirmed`.
 
 ### Compilación de datos de transacciones
 

--- a/src/content/docs/es/user-guide/bridge.mdx
+++ b/src/content/docs/es/user-guide/bridge.mdx
@@ -115,11 +115,11 @@ El estado de rollup `Finalizado` indica que se ha comprobado la correcta ejecuci
 
 {/* <ClickToZoom src={bridge6} /> */}
 
-{/* It will open the _Transaction Details_ page in a new tab. You can see this transaction is confirmed on L2. */}
+{/* It will open the _Transaction Details_ page in a new tab. You can see this transaction is pre-confirmed on L2. */}
 
 {/* <ClickToZoom src={bridge7} /> */}
 
-{/* The transaction is confirmed on L2, but still needs to be finalized on Goerli. */}
+{/* The transaction is pre-confirmed on L2, but still needs to be finalized on Goerli. */}
 
 {/* 1. Go back to the [Bridge](https://scroll.io/bridge) app. It takes about 10 minutes before the token shows up in your Goerli wallet. Once your transaction status shows success on L2, you should see the funds in your Goerli wallet and a transaction hash: */}
 

--- a/src/content/docs/tr/user-guide/bridge.mdx
+++ b/src/content/docs/tr/user-guide/bridge.mdx
@@ -113,11 +113,11 @@ Rollup durumu `Kesinleştirildi`, bu bloktaki işlemlerin doğru bir şekilde y�
 
 {/* <ClickToZoom src={bridge6} /> */}
 
-{/* It will open the _Transaction Details_ page in a new tab. You can see this transaction is confirmed on L2. */}
+{/* It will open the _Transaction Details_ page in a new tab. You can see this transaction is pre-confirmed on L2. */}
 
 {/* <ClickToZoom src={bridge7} /> */}
 
-{/* The transaction is confirmed on L2, but still needs to be finalized on Goerli. */}
+{/* The transaction is pre-confirmed on L2, but still needs to be finalized on Goerli. */}
 
 {/* 1. Go back to the [Bridge](https://scroll.io/bridge) app. It takes about 10 minutes before the token shows up in your Goerli wallet. Once your transaction status shows success on L2, you should see the funds in your Goerli wallet and a transaction hash: */}
 

--- a/src/content/docs/zh/technology/chain/transactions.mdx
+++ b/src/content/docs/zh/technology/chain/transactions.mdx
@@ -50,7 +50,7 @@ type L1MessageTx struct {
 
 Scroll 中的交易生命周期包含以下三个阶段：
 
-1. **已确认（Confirmed）**: 用户向 L1 跨链桥合约或 L2 排序器提交交易。交易执行并包含在 L2 区块中后变为 `已确认` 。
+1. **已确认（Pre-Confirmed）**: 用户向 L1 跨链桥合约或 L2 排序器提交交易。交易执行并包含在 L2 区块中后变为 `已确认` 。
 2. **已提交（Committed）**: 交易被包含在批次(batch)中，并且包含此批处理数据的 *承诺交易（commit transaction* 将提交到 L1。在 L1 区块中确认承诺事务后，此批处理中的交易变为`已提交`。
 3. **最终确认（Finalized）**: 该批次的证明生成并在L1上得到验证。在 *最终确认交易(finalize transaction)* 在 L1 上最终确认后，交易状态变为 `最终确认` 并成为 Scroll L2 链的一部分。
 
@@ -66,7 +66,7 @@ Scroll 中的交易生命周期包含以下三个阶段：
 - `L1ScrollMessenger` 合约允许用户和合约向 L2 发送任意消息。更多详细信息，请参阅[发送任意消息](/UPyw7afFQE6q-9CIdIRBag#Sending-Arbitrary-Messages)。
 - `EnforcedTxGateway` 合约允许EOA从同一地址发起强制交易，以提取代币或在L2上调用其他合约。更多详细信息，请参阅[发送强制交易](/UPyw7afFQE6q-9CIdIRBag#Sending-Enforced-Transactions)。
 
-Scroll 排序器会定期开始新的mining任务。它会从 `L1MessageQueue` 合约和 L2 内存池中的交易中提取 L1 消息并密封一个区块。一旦交易被包含在 L2 区块中，其状态将变为 `Confirmed` 。
+Scroll 排序器会定期开始新的mining任务。它会从 `L1MessageQueue` 合约和 L2 内存池中的交易中提取 L1 消息并密封一个区块。一旦交易被包含在 L2 区块中，其状态将变为 `Pre-Confirmed` 。
 
 ### 承诺交易数据
 

--- a/src/content/docs/zh/user-guide/bridge.mdx
+++ b/src/content/docs/zh/user-guide/bridge.mdx
@@ -115,11 +115,11 @@ Rollup 状态 `最终确认` 表明，通过在Sepolia上验证链上的有效�
 
 {/* <ClickToZoom src={bridge6} /> */}
 
-{/* It will open the _Transaction Details_ page in a new tab. You can see this transaction is confirmed on L2. */}
+{/* It will open the _Transaction Details_ page in a new tab. You can see this transaction is pre-confirmed on L2. */}
 
 {/* <ClickToZoom src={bridge7} /> */}
 
-{/* The transaction is confirmed on L2, but still needs to be finalized on Goerli. */}
+{/* The transaction is pre-confirmed on L2, but still needs to be finalized on Goerli. */}
 
 {/* 1. Go back to the [Bridge](https://scroll.io/bridge) app. It takes about 10 minutes before the token shows up in your Goerli wallet. Once your transaction status shows success on L2, you should see the funds in your Goerli wallet and a transaction hash: */}
 


### PR DESCRIPTION
## Description
To be more precise when talking about transactions being included in an L2 block by a sequencer, we should use the word `pre-confirmed` instead of `confirmed`. This also helps avoid confusion with being `confirmed` on L1.

## Changes
Rename `Confirmed` to `Pre-Confirmed`

cc @Thegaram 
