### PR TITLE
corrected text for transaction execution explanation

### DIFF
--- a/src/content/docs/en/learn/intro-to-rollups.md
+++ b/src/content/docs/en/learn/intro-to-rollups.md
@@ -14,7 +14,7 @@ Rollups are the most predominant layer 2 scaling solution in the Ethereum ecosys
 
 A rollup processes batches of transactions off-chain (i.e. not on layer 1), and then posts the resulting data on-chain (i.e. on layer 1).
 
-The execution of each transaction is performed off-chain, and does not need to be re-executed layer 1 nodes. This allows for high transaction throughput, without impacting the decentralization of layer 1.
+The execution of each transaction is performed off-chain and does not need to be re-executed by layer 1 nodes. This allows for high transaction throughput without impacting the decentralization of layer 1.
 
 In order for a rollup to be secure, it must prove that its off-chain computation (the processing of transactions) was performed correctly. There are predominantly two mechanisms to prove the validity of off-chain computation: validity proofs and fraud proofs.
 


### PR DESCRIPTION
This pull request addresses the following issue: #287 

## Description
After a careful read through the Scroll documentation while writing my report on zk-proofs, I found some mistakes that I believe the team didn't notice. I decided to submit a pull request with these findings and corrections as my small contribution to the Scroll docs. As someone passionate about blockchain technology and zk-proof scaling solutions, I believe these corrections address the issues in the original Scroll docs.

## Changes
"The execution of each transaction is performed off-chain and does not need to be re-executed by layer 1 nodes. This allows for high transaction throughput without impacting the decentralization of layer 1"
1:Added "by" before "layer 1 nodes" for clarity.
2:Removed the comma before "without" to improve readability.

#287 
##problem solved
"The execution of each transaction is performed off-chain, and does not need to be re-executed layer 1 nodes. This allows for high transaction throughput, without impacting the decentralization of layer 1"

## file changed
1:intro-to-rollups.md 

## Functional Improvements
1:Improved Accuracy: The updated text provides a more precise description of transaction execution mechanisms.
2:Enhanced Clarity: Ensured that the documentation is clear and easy to understand for readers.


I hope these corrections will be reviewed and incorporated to improve the overall quality of the Scroll documentation. Thank you for considering my contribution.