### PR TITLE
Enable RPC connections from within the local docker network.

### DIFF
--- a/src/content/docs/en/developers/guides/running-a-scroll-node.mdx
+++ b/src/content/docs/en/developers/guides/running-a-scroll-node.mdx
@@ -115,7 +115,7 @@ Running the node in Docker might have a significant impact on node performance.
         --scroll \
         --datadir "/volume/l2geth-datadir" \
         --gcmode archive --cache.noprefetch \
-        --http --http.addr "0.0.0.0" --http.port 8545 --http.api "eth,net,web3,debug,scroll" \
+        --http --http.addr "0.0.0.0" --http.port 8545 --http.api "eth,net,web3,debug,scroll" --http.vhosts=* \
         --l1.endpoint "$L2GETH_L1_ENDPOINT" --rollup.verify
     ```
     For Scroll Sepolia, set the chain ID to 534351.


### PR DESCRIPTION
## Description

The docker container does not accept HTTP RPC requests from other containers within the same local docker network. It responds with HTTP status "403 invalid host specified".

## Changes

Add the option `--http.vhosts=*` to the `docker run ...` command line.

See  https://github.com/ethereum/go-ethereum/issues/16526#issuecomment-992480651

and https://geth.ethereum.org/docs/fundamentals/command-line-options
