### PR TITLE
[Enhancement]: Cookbook Onboard integration (AI Assistant)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@astrojs/partytown": "^2.0.4",
     "@astrojs/prism": "^3.0.0",
     "@astrojs/tailwind": "^5.1.0",
+    "@cookbookdev/docsbot": "^4.21.5",
     "@nanostores/preact": "^0.3.1",
     "astro-auto-import": "^0.4.2",
     "astro-expressive-code": "^0.35.3",

--- a/src/components/AskCookbook.astro
+++ b/src/components/AskCookbook.astro
@@ -1,0 +1,10 @@
+---
+import AskCookbook from "@cookbookdev/docsbot/react"
+
+// API key is public so it's fine to just hardcode it here.
+const COOKBOOK_PUBLIC_API_KEY =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2NjhkNGNkNDQ5ODQ2YjcxMDdjYjY4MDgiLCJpYXQiOjE3MjA1MzYyNzYsImV4cCI6MjAzNjExMjI3Nn0.ZQ6KvZ4lRGTQUyleQFS0okdNOhZI_wsv2v9YFn2t6Pw"
+---
+
+<!-- Cookbook Onboard (AI Assistant).  -->
+<AskCookbook apiKey={COOKBOOK_PUBLIC_API_KEY} client:only="react" />

--- a/src/layouts/HomeLayout.astro
+++ b/src/layouts/HomeLayout.astro
@@ -5,6 +5,7 @@ import Header from "../components/Header/Header.astro"
 import * as CONFIG from "../config"
 import Footer from "~/components/Footer/Footer.astro"
 import LeftSidebar from "../components/LeftSidebar/LeftSidebar.astro"
+import AskCookbook from "~/components/AskCookbook.astro"
 
 const { content = {} } = Astro.props
 const currentPage = new URL(Astro.request.url).pathname
@@ -87,5 +88,6 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
       <slot />
     </main>
     <Footer />
+    <AskCookbook />
   </body>
 </html>

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -10,6 +10,7 @@ import * as CONFIG from "../config"
 import Footer from "~/components/Footer/Footer.astro"
 import { changeLanguage } from "i18next"
 import { ViewTransitions } from "astro:transitions"
+import AskCookbook from "~/components/AskCookbook.astro"
 
 const { content = {}, frontmatter } = Astro.props
 // Astro.props?.headings is for .mdx pages, Astro.props?.content?.astro.headings is for .md pages
@@ -248,5 +249,6 @@ changeLanguage(content.lang)
         import("../scripts/link-to-wallet.ts")
       }
     </script> -->
+    <AskCookbook />
   </body>
 </html>


### PR DESCRIPTION
[Enhancement]: Cookbook Onboard integration (AI Assistant) 

## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

closes #309 

## Description

<!-- Please provide enough information so that others can review your pull request: -->

The AI assistant and co-pilot is trained on all existing Scroll resources (source code, docs website, etc) and is available as a standalone modal, embeddable as a button on any page (recommended for technical docs). It answers developer questions about building projects on Scroll, acting as an enhanced and streamlined technical documentation search tool as well as a Solidity coding co-pilot.

Ask Cookbook AI could also access context from thousands of data sources indexed by Cookbook.dev in addition to Scroll-specific data sources, providing the best blockchain developer-focused answers of any chatbot on the market. Cookbook will assist in the tuning and calibration of the AI assistant to ensure the highest answer quality.

## Preview
https://docsbot-demo-git-scroll-cookbookdev.vercel.app/

![image](https://github.com/user-attachments/assets/ea75a51b-eb13-4cca-b9fc-786275e50086)


## Changes
- Added @cookbookdev/docsbot package
- Added it to the `src/layouts/MainLayout.astro`
