### PR TITLE
added guide for the graph

### DIFF
--- a/src/content/tools/en/thegraph.mdx
+++ b/src/content/tools/en/thegraph.mdx
@@ -1,0 +1,25 @@
+---
+name: "The Graph"
+category: ["Debug", "Data"]
+excerpt: "Getting historical data on a smart contract can be frustrating when you’re building a dapp. The Graph provides an easy way to query smart contract data through APIs known as subgraphs."
+logo: { src: "https://pbs.twimg.com/profile_images/1735767195567730688/goqgFT93_400x400.jpg", alt: "The Graph Logo" }
+website: "https://thegraph.com"
+network: ["Mainnet", "Testnet"]
+---
+
+Getting historical data on a smart contract can be frustrating when you’re building a dapp. [The Graph](https://thegraph.com/) provides an easy way to query smart contract data through APIs known as subgraphs. The Graph’s infrastructure relies on a decentralized network of indexers, enabling your dapp to become truly decentralized.
+
+The Graph supports both Scroll mainnet & testnet.
+
+#### Quick Start
+
+These subgraphs only take a few minutes to set up. To get started, follow these three steps:
+
+1. Initialize your subgraph project
+2. Deploy & Publish
+3. Query from your dapp
+
+Pricing: **All developers receive 100K free queries per month on the decentralized network**. After these free queries, you only pay based on usage at $4 for every 100K queries.
+
+Here’s a step by step walk through that includes screenshots:
+[The Graph Quick Start](https://edgeandnode.notion.site/The-Graph-Quick-Start-cd924d4d17674c5492216ef7c5e0503d?pvs=74)  


### PR DESCRIPTION
Added a page in the Devs Tooling section for The Graph.
It's a most up to date guide on how to create & deploy a subgraph, and then query it on the decentralized network.