### PR TITLE
Update required Go version

### DIFF
--- a/src/content/docs/en/developers/guides/running-a-scroll-node.mdx
+++ b/src/content/docs/en/developers/guides/running-a-scroll-node.mdx
@@ -49,7 +49,7 @@ You will need access to a fully-synced **Ethereum Mainnet** or **Ethereum Sepoli
     $ cd l2geth-source
     $ git checkout VERSION
     ```    
-2. Ensure that you are using version 1.20 of `go`.
+2. Ensure that you are using version 1.21 of `go`.
 3. Install the gcc compiler: `sudo apt install build-essential`.
 4. Build `l2geth`: `make nccc_geth`. The binary is now in `build/bin/geth`.
 5. Define a command alias: `alias l2geth=./build/bin/geth`.


### PR DESCRIPTION
Currently exactly go 1.21 is required. Compilation fails with 1.23 and 1.20.

## Closing issues
closes #335 

## Changes
Just change the Go version from 1.20 to 1.21 in the docs.