### PR TITLE
added xDomainMessageSender to the-scroll-messenger.mdx

### DIFF
--- a/src/content/docs/en/developers/l1-and-l2-bridging/the-scroll-messenger.mdx
+++ b/src/content/docs/en/developers/l1-and-l2-bridging/the-scroll-messenger.mdx
@@ -146,3 +146,12 @@ Relay a L2 => L1 message with message proof.
 | nonce     | The nonce of the message to avoid replay attack.             |
 | message   | The content of the message.                                  |
 | proof     | The proof used to verify the correctness of the transaction. |
+
+### xDomainMessageSender
+`xDomainMessageSender` contains the address of the `msg.sender` that called `sendMessage` on the other chain.  
+```solidity
+address public override xDomainMessageSender;
+```  
+Note: `xDomainMessageSender` resets after the `relayMessageWithProof` function ends.  
+Make sure that only the `scrollMessenger` contract can call functions that use `xDomainMessageSender`.    
+See the [scroll contracts](/developers/scroll-contracts/#advanced-bridge-contracts) page to see the scrollMessenger contract addresses.  


### PR DESCRIPTION
## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

closes #343

## Description

<!-- Please provide enough information so that others can review your pull request: -->
This adds `xDomainMessageSender` to the ["/the-scroll-messenger" page](https://docs.scroll.io/en/developers/l1-and-l2-bridging/the-scroll-messenger/)   
xDomainMessageSender allows developers to see which address initiated the bridge transaction. And allows them to make sure it was the correct contract. 

## Changes

<!--Explain the **details** for making this change. What existing problem does the pull request solve? -->
Adds a brief description of xDomainMessageSender.  
