### PR TITLE
fix: syntax error

### DIFF
--- a/src/content/docs/en/developers/transaction-fees-on-scroll.mdx
+++ b/src/content/docs/en/developers/transaction-fees-on-scroll.mdx
@@ -30,7 +30,7 @@ At a high level, the **L2 fee** is the cost of executing your transaction on the
 In short, `totalTxFee = l2Fee + l1Fee`, all denominated in ETH, the native gas token for the Scroll network.
 
 <Aside type="note" title="Where are transaction fees sent?">
-All tx fees are collected into the `L2ScrollFeeVault` contract balance. This contract also tracks the amount we’ve historically withdrawn to L1 using `totalProcessed()(uint256)`.
+All tx fees are collected into the `L2ScrollFeeVault` contract balance. This contract also tracks the amount we’ve historically withdrawn to L1 using `totalProcessed() returns (uint256)`.
 
 The block producer receives no direct reward, and the `COINBASE` opcode returns the fee vault address.
 


### PR DESCRIPTION
closes #353 
...

## Description

Fixed a syntax error in the L2ScrollFeeVault contract. The function declaration for totalProcessed was incorrectly using parentheses with the return type. This change corrects the function syntax to comply with Solidity standards.



...

## Changes

Updated the totalProcessed function in the L2ScrollFeeVault contract from: totalProcessed()(uint256) to totalProcessed() returns (uint256)

- High level
- changes that
- you made
- ...
