### PR TITLE
fix: Corrected Grammatical Errors in Documentation

### DIFF
--- a/src/content/docs/en/developers/l1-and-l2-bridging/erc1155-token-bridge.mdx
+++ b/src/content/docs/en/developers/l1-and-l2-bridging/erc1155-token-bridge.mdx
@@ -16,7 +16,7 @@ ERC1155 bridging from L1 to L2 is done via the L1ERC1155Gateway. Similarly to ER
 
 <Aside type="tip" title="">
   **`depositERC1155`** is a payable function, and the amount of ETH sent to this function will be used to pay for L2
-  fees. If the amount is not enough, the transaction will not be sent. All excess eth will be sent back to the sender.
+  fees. If the amount is not enough, the transaction will not be sent. All excess ETH will be sent back to the sender.
   `0.00001 ETH` should be more than enough to process a token deposit.
 </Aside>
 
@@ -87,7 +87,7 @@ The `L2ERC1155Gateway` contract is used to send tokens from L2 to L1. Before bri
 
 <Aside type="caution" title="">
   **Make sure the transaction won't revert on L1** while sending from L2. There is no way to recover tokens bridged if
-  you're transaction reverts on L1. All assets are burnt on L2 when the transaction is sent, and it's impossible to mint
+  your transaction reverts on L1. All assets are burnt on L2 when the transaction is sent, and it's impossible to mint
   them again.
 </Aside>
 

--- a/src/content/docs/en/developers/l1-and-l2-bridging/erc721-nft-bridge.mdx
+++ b/src/content/docs/en/developers/l1-and-l2-bridging/erc721-nft-bridge.mdx
@@ -14,11 +14,11 @@ import Aside from "../../../../../components/Aside.astro"
 
 NFT bridging from L1 to L2 is done via the `L1ERC721Gateway` contract instead of using a router. Similarly to bridging ERC20 tokens, we use the `depositERC721` function to send tokens to L2, and we can later retrieve them back to L1 using `withdrawERC721` on the `L2ERC721Gateway` contract deployed on L2.
 
-NFT contracts on both L1 and l2 must be launched and connected through the Gateways to enable bridging. This means deposit and withdraw transactions will revert if a contract on either L1 or L2 is missing or not mapped through the `updateTokenMapping` function.
+NFT contracts on both L1 and L2 must be launched and connected through the Gateways to enable bridging. This means deposit and withdraw transactions will revert if a contract on either L1 or L2 is missing or not mapped through the `updateTokenMapping` function.
 
 <Aside type="tip" title="">
   **`depositERC721`** is a payable function. The amount of ETH sent to this function will be used to pay for L2 fees. If
-  the amount is not enough, the transaction will not be sent. All excess eth will be sent back to the sender. `0.00001
+  the amount is not enough, the transaction will not be sent. All excess ETH will be sent back to the sender. `0.00001
   ETH` should be more than enough to process a token deposit.
 </Aside>
 


### PR DESCRIPTION
## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

closes #355 

## Description

Corrected grammatical errors throughout the documentation. 


## Changes

1) https://github.com/scroll-tech/scroll-documentation/blob/develop/src/content/docs/en/developers/guides/scroll-messenger-cross-chain-interaction.mdx
2) https://github.com/scroll-tech/scroll-documentation/blob/develop/src/content/docs/en/developers/l1-and-l2-bridging/erc721-nft-bridge.mdx
3) https://github.com/scroll-tech/scroll-documentation/blob/develop/src/content/docs/en/user-guide/bridge.mdx



