### PR TITLE
Docs update: Adding Reown as one of the Tooling deployed on Scroll

### DIFF
--- a/src/content/tools/en/reown.mdx
+++ b/src/content/tools/en/reown.mdx
@@ -1,0 +1,28 @@
+---
+name: "Reown (prev. known as WalletConnect)"
+category: ["Wallet"]
+excerpt: ""
+logo: { src: "https://avatars.githubusercontent.com/u/179229932", alt: "Reown Logo" }
+website: "https://reown.com/?utm_source=scroll&utm_medium=docs&utm_campaign=backlinks"
+network: ["Mainnet", "Testnet"]
+---
+
+**[Reown](https://reown.com/?utm_source=scroll&utm_medium=docs&utm_campaign=backlinks)** gives developers the tools to build user experiences that make digital ownership effortless, intuitive, and secure.
+
+Reown has two major product offerings, they are, **AppKit** and **WalletKit**.
+
+### AppKit
+
+AppKit is a powerful, free, and fully open-source SDK for developers looking to integrate wallet connections and other Web3 functionalities into their apps on any EVM and non-EVM chain. In just a few simple steps, you can provide your users with seamless wallet access, one-click authentication, social logins, and notifications—streamlining their experience while enabling advanced features like on-ramp functionality, in-app token swaps and smart accounts.
+
+### WalletKit
+WalletKit is a robust, open-source SDK designed to empower seamless wallet connections and interactions across any blockchain. With WalletKit, you can offer your users a simple and secure way to connect with thousands of apps, enabling features like one-click authentication, secure transaction signing, and streamlined wallet address verification. Its chain-agnostic design ensures effortless multi-chain support, eliminating the need for complex integrations while delivering unmatched connectivity and security.
+
+To summarize, **AppKit** is for **Web3 applications** and **WalletKit** is for **Web3 wallets**.
+
+You will be able to use Reown AppKit to power end-to-end wallet interactions on your Web3 app deployed on Scroll.
+
+Some links to learn more about Reown:
+- [Website](https://reown.com/?utm_source=scroll&utm_medium=docs&utm_campaign=backlinks)
+- [Blog](https://reown.com/blog?utm_source=scroll&utm_medium=docs&utm_campaign=backlinks)
+- [Docs](https://docs.reown.com/?utm_source=scroll&utm_medium=docs&utm_campaign=backlinks)

--- a/src/content/tools/en/reown.mdx
+++ b/src/content/tools/en/reown.mdx
@@ -1,13 +1,13 @@
 ---
-name: "Reown (prev. known as WalletConnect)"
+name: "Reown"
 category: ["Onboarding", "Wallet"]
-excerpt: ""
+excerpt: "Reown provides developers with tools to enable seamless wallet interactions across their Web3 apps and wallets."
 logo: { src: "https://avatars.githubusercontent.com/u/179229932", alt: "Reown Logo" }
 website: "https://reown.com/?utm_source=scroll&utm_medium=docs&utm_campaign=backlinks"
 network: ["Mainnet", "Testnet"]
 ---
 
-**[Reown](https://reown.com/?utm_source=scroll&utm_medium=docs&utm_campaign=backlinks)** gives developers the tools to build user experiences that make digital ownership effortless, intuitive, and secure.
+**[Reown (prev. known as WalletConnect)](https://reown.com/?utm_source=scroll&utm_medium=docs&utm_campaign=backlinks)** provides developers with tools to enable seamless wallet interactions across their Web3 apps and wallets.
 
 Reown has two major product offerings, they are, **AppKit** and **WalletKit**.
 

--- a/src/content/tools/en/reown.mdx
+++ b/src/content/tools/en/reown.mdx
@@ -1,6 +1,6 @@
 ---
 name: "Reown (prev. known as WalletConnect)"
-category: ["Wallet"]
+category: ["Onboarding", "Wallet"]
 excerpt: ""
 logo: { src: "https://avatars.githubusercontent.com/u/179229932", alt: "Reown Logo" }
 website: "https://reown.com/?utm_source=scroll&utm_medium=docs&utm_campaign=backlinks"


### PR DESCRIPTION
## Closing issues

closes #400 
...

## Description

This PR adds another developer tooling deployed on Scroll, that is, Reown (prev. known as WalletConnect).

...

## Changes

Adds another `.mdx` file within `/tools/en` folder. The markdown file also contains information about Reown and its two major SDKs for user onboarding and wallets.
