### PR TITLE
docs: (contributing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Contribute to Scroll](./src/assets/banner.png)
 
 [![Twitter Follow](https://img.shields.io/twitter/follow/Scroll_ZKP?style=social)](https://twitter.com/Scroll_ZKP)
-[![Discord](https://img.shields.io/discord/984015101017346058?color=%235865F2&label=Discord&logo=discord&logoColor=%23fff)](https://discord.gg/scroll)
+[![Discord](https://img.shields.io/badge/discord-join%20chat-5B5EA6)](https://discord.gg/scroll)
 
 This is the open source project for the Scroll documentation.
 


### PR DESCRIPTION
the previous shield on Discord was incorrect, it reflected the number of online users at 23 thousand, although in reality it is now 18 thousand. I wanted to replace it with a real link, but the widget is now buried

https://img.shields.io/discord/853955156100907018?color=%235865F2&label=Discord&logo=discord&logoColor=%23fff

## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

closes #ISSUE_NUMBER_GOES_HERE

...

## Description

<!-- Please provide enough information so that others can review your pull request: -->

...

## Changes

<!--Explain the **details** for making this change. What existing problem does the pull request solve? -->

- High level
- changes that
- you made
- ...
