### PR TITLE
Fix: Add contract link for Euclid update Phase 2

### DIFF
--- a/src/content/docs/en/technology/overview/scroll-upgrades.mdx
+++ b/src/content/docs/en/technology/overview/scroll-upgrades.mdx
@@ -114,7 +114,7 @@ Please refer to [Node Runner State Migration Guideline](https://www.notion.so/No
 In addition, L2 unsafe blocks will no longer include a signature or vanity tag in the `ExtraData` field.
 
 #### Resources
-* [Contract changes on GitHub](https://github.com/scroll-tech/scroll-contracts/pull/79)
+* Contract changes on GitHub: [Phase 1](https://github.com/scroll-tech/scroll-contracts/pull/79) | [Phase 2](https://github.com/scroll-tech/scroll-contracts/pull/74)
 * [DA codec repository](https://github.com/scroll-tech/da-codec)
 
 Projects requiring additional guidance should open a [ticket on Discord](https://discord.com/channels/853955156100907018/1280768286124146732).


### PR DESCRIPTION
Original link didn't include contract changes for Phase 2, including changes to ScrollChain.