### PR TITLE
Add ethfaucet.com faucet

### DIFF
--- a/src/content/docs/en/developers/faucet.mdx
+++ b/src/content/docs/en/developers/faucet.mdx
@@ -28,6 +28,7 @@ Here are a few Sepolia faucet apps:
 - [Chainstack Faucet](https://faucet.chainstack.com)
 - [Infura Faucet](https://infura.io/faucet/sepolia)
 - [Ethereum Ecosystem Faucets](https://www.ethereum-ecosystem.com/faucets/ethereum-sepolia)
+- [ethfaucet.com](https://ethfaucet.com?utm_source=scroll_docs&utm_medium=docs)
 
 ### Scroll Sepolia Faucets
 
@@ -40,4 +41,5 @@ If you don't want to interact with the bridge, some faucets directly distribute 
 - [Chainstack Scroll Sepolia](https://faucet.chainstack.com/scroll-sepolia-testnet-faucet)
 - [Bware Labs Faucet](https://bwarelabs.com/faucets/scroll-testnet)
 - [L2 Faucet](https://www.l2faucet.com/scroll)
+- [ethfaucet.com](https://ethfaucet.com?utm_source=scroll_docs&utm_medium=docs)
 


### PR DESCRIPTION
## Closing issues
closes #545

...

## Description
Adding a new faucet (ethfaucet.com) to the docs.
ethfaucet.com provides developers with 0.1 Scroll testnet ETH for free, claimable once every 24 hours.

## Additional context
ethfaucet.com is maintained and powered by BringID. BringID is a proof-of-humanity solution from web accounts helping crypto apps to resist sybil attacks and bot abuse.
