### PR TITLE
docs: improve grammar and terminology consistency in Building on Scroll

### DIFF
--- a/src/content/docs/en/developers/building-on-scroll.mdx
+++ b/src/content/docs/en/developers/building-on-scroll.mdx
@@ -13,22 +13,22 @@ import ToggleElement from "../../../../components/ToggleElement.astro"
 
 **Welcome to the Scroll developer documentation!**
 
-Scroll is its own Layer 2 network built on Ethereum (more specifically, a “zero knowledge rollup”).
+Scroll is its own Layer 2 network built on Ethereum (more specifically, a "zero-knowledge rollup").
 
-If you’re experienced in building on Ethereum, your code, dependencies, and tooling work with Scroll out of the box. This is possible because our network is compatible with EVM bytecode and designed to feel just like developing on Ethereum.
+If you're experienced in building on Ethereum, your code, dependencies, and tooling work with Scroll out of the box. This is possible because our network is compatible with EVM bytecode and designed to feel just like developing on Ethereum.
 
-<Aside type="tip" title="New to zero knowledge rollups?">
-Scroll gains its security and speed by executing transactions off-chain, and also producing a cryptographic proof that
-the transactions were executed correctly. This cryptographic proof is verified in a smart contract on Layer 1,
-ensuring that all code executed on the Scroll Layer 2 behaves just as if it were executed on Ethereum Layer 1.
+<Aside type="tip" title="New to zero-knowledge rollups?">
+Scroll gains its security and speed by executing transactions off-chain and producing a cryptographic proof that
+the transactions were executed correctly. This cryptographic proof is verified in a smart contract on L1,
+ensuring that all code executed on Scroll L2 behaves just as if it were executed on Ethereum L1.
 
-[Learn more about Scroll’s architecture →](/technology)
+[Learn more about Scroll's architecture →](/technology)
 
 </Aside>
 
 ## Getting Started
 
-**Looking to build on the Scroll?**
+**Looking to build on Scroll?**
 
 - Check out our [FAQ](/developers/) for the essentials
 - Follow our [guide](/developers/guides/running-a-scroll-node) to run Scroll L2geth Node
@@ -37,24 +37,24 @@ ensuring that all code executed on the Scroll Layer 2 behaves just as if it were
 ## Why Build on Scroll?
 
 <ToggleElement anchor="throughput">
-  <div slot="title">Throughput — Scroll creates more secure blockspace for Ethereum.</div>
+  <div slot="title">Throughput - Scroll creates more secure blockspace for Ethereum.</div>
   <p>
     ZK Rollups allow for more activity on the network, minimizing congestion. By inheriting the security of Ethereum,
-    which verifies the behavior of the network using zero knowledge proofs, Scroll can process more transactions without
+    which verifies the behavior of the network using zero-knowledge proofs, Scroll can process more transactions without
     compromising on decentralization.
   </p>
 </ToggleElement>
 
 <ToggleElement anchor="cost">
-  <div slot="title">Cost — Scroll saves users gas fees.</div>
+  <div slot="title">Cost - Scroll saves users gas fees.</div>
   <p>
     On Ethereum, competition for blockspace results in higher costs per transaction, as each transaction makes a bid to
-    be included in the next block. Scroll leverages recent breakthroughs in zero knowledge proofs and hardware
+    be included in the next block. Scroll leverages recent breakthroughs in zero-knowledge proofs and hardware
     acceleration to vastly increase secure blockspace and minimize transaction costs for users.
   </p>
 </ToggleElement>
 <ToggleElement anchor="speed">
-  <div slot="title">Speed — Scroll delivers feedback to users, faster.</div>
+  <div slot="title">Speed — Scroll delivers feedback to users faster.</div>
   <p>
     After the merge, Ethereum blocks reliably confirm every 12 seconds. Scroll blocks are minted every 3 seconds, and
     for the sake of lower-risk operations, transactions can be assumed to be final once included in a block. This opens
@@ -62,25 +62,25 @@ ensuring that all code executed on the Scroll Layer 2 behaves just as if it were
   </p>
 </ToggleElement>
 <ToggleElement anchor="alignment">
-  <div slot="title">Alignment — Scroll builds on Ethereum's vision.</div>
+  <div slot="title">Alignment - Scroll builds on Ethereum's vision.</div>
   <p>
-    Scroll builds on Ethereum’s vision. Our ethos is to build Ethereum, not to splinter it. Decentralization,
-    permissionlessness, censorship-resistance, and community ownership are the core of what we do and the roadmap we’re
-    building. We believe in open-source software, and we work closely with the Ethereum Foundation’s Privacy and Scaling
+    Scroll builds on Ethereum's vision. Our ethos is to build Ethereum, not to splinter it. Decentralization,
+    permissionlessness, censorship-resistance, and community ownership are the core of what we do and the roadmap we're
+    building. We believe in open-source software, and we work closely with the Ethereum Foundation's Privacy and Scaling
     Explorations team to support their work on a zkEVM that might someday be the heart of Ethereum.
   </p>
   <p>
     We also work with governance DAOs and other open-source protocols to make sure that as applications are deployed,
-    we’re working to grow their impact — whether that be in public goods, core infrastructure, or the next generation of
-    zero knowledge use cases.
+    we're working to grow their impact - whether that be in public goods, core infrastructure, or the next generation of
+    zero-knowledge use cases.
   </p>
 </ToggleElement>
 <ToggleElement anchor="community">
-  <div slot="title">Community — Scroll brings together users and builders.</div>
+  <div slot="title">Community - Scroll brings together users and builders.</div>
   <p>
     We know the challenges of building in the open and getting user engagement! Scroll has a blossoming community of
     users and builders, and with a Discord community of over 500,000 members eager to try out applications on our
-    testnet or mainnet, we’re excited to connect builders with users who can provide real-world feedback.
+    testnet or mainnet, we're excited to connect builders with users who can provide real-world feedback.
   </p>
 </ToggleElement>
 

--- a/src/content/docs/en/developers/developer-ecosystem.mdx
+++ b/src/content/docs/en/developers/developer-ecosystem.mdx
@@ -63,7 +63,7 @@ Bridges provide not only ERC-20 token transfers but also are able to send arbitr
 
 # Borrowing & Lending Platforms
 
-Borrowing and lending platforms let users earn yield, leverage positions or protect against volatility. TVL data is available on [DeFiLlama](https://defillama.com/protocols/lending/Scroll), where the higher the more stable rates and yields. The chart below compares transaction counts across each platform indicating users pereference.
+Borrowing and lending platforms let users earn yield, leverage positions or protect against volatility. TVL data is available on [DeFiLlama](https://defillama.com/protocols/lending/Scroll), where the higher the more stable rates and yields. The chart below compares transaction counts across each platform indicating user preference.
 
 <iframe src="https://dune.com/embeds/5514443/8981638"/>
 
@@ -74,10 +74,10 @@ Borrowing and lending platforms let users earn yield, leverage positions or prot
 | LayerBank | [LayerBank Contracts](https://github.com/layerbank-foundation/v2-contracts) | [Layer Bank V2 Documentation](https://docs.layerbank.finance/) |
 | Rho Markets | [Rho Markets Contracts](https://docs.rhomarkets.xyz/protocol/rho-markets-contract-overview#core-contracts) | [Rho Markets Documentation](https://docs.rhomarkets.xyz/) |
 | Morpho | [Morpho Contracts](https://docs.morpho.org/getting-started/resources/addresses#morpho-contracts) | [Morpho Documentation](https://docs.morpho.org/)  |
-| Compound | [Compund Contracts](https://docs.compound.finance/#protocol-contracts) | [Compund Documentation](https://docs.compound.finance/#compound-iii) |
+| Compound | [Compound Contracts](https://docs.compound.finance/#protocol-contracts) | [Compound Documentation](https://docs.compound.finance/#compound-iii) |
 
 # ETH Liquid Staking & Rebase Tokens
 
-Liquid Staking Tokens produce yield by just holding them on the wallet by a process called Rebase. Higher market cap indicates more accesibility to users.
+Liquid Staking Tokens produce yield by just holding them on the wallet by a process called Rebase. Higher market cap indicates more accessibility to users.
 
 <iframe src="https://dune.com/embeds/5515252/8983149"/>

--- a/src/content/docs/en/developers/ethereum-and-scroll-differences.mdx
+++ b/src/content/docs/en/developers/ethereum-and-scroll-differences.mdx
@@ -26,7 +26,7 @@ For open-source contributors and infrastructure builders, please contact our tea
 | `BLOCKHASH`                 | `block.blockhash`   | Returns `keccak(chain_id \|\| block_number)` for the last 256 blocks.                                      |
 | `COINBASE`                  | `block.coinbase`    | Returns the pre-deployed fee vault contract address. See [Scroll Contracts](/developers/scroll-contracts). |
 | `DIFFICULTY` / `PREVRANDAO` | `block.difficulty`  | Returns 0.                                                                                                 |
-| `SELFDESTRUCT`              | `selfdestruct`      | Disabled. If the opcode is encountered, the transaction will be reverted.[^willadpot]                      |
+| `SELFDESTRUCT`              | `selfdestruct`      | Disabled. If the opcode is encountered, the transaction will be reverted.[^willadopt]                      |
 
 <Aside type="caution" title="">
 Opcodes related to EIP-4844, like `BLOBHASH` and `BLOBBASEFEE`, are not yet available on Scroll. Additionally, [EIP-4788](https://eips.ethereum.org/EIPS/eip-4788) for accessing the Beacon Chain block root is not supported.
@@ -34,23 +34,23 @@ Opcodes related to EIP-4844, like `BLOBHASH` and `BLOBBASEFEE`, are not yet avai
 
 We support the `cancun` EVM target and the latest Solidity version `0.8.26`.
 
-[^willadpot]: Will change to adopt Ethereum’s solution in the future.
+[^willadopt]: Will change to adopt Ethereum's solution in the future.
 
 ## EVM Precompiles
 
-The `RIPEMD-160` (address `0x3`) `blake2f` (address `0x9`), and `point evaluation` (address `0x0a`) precompiles are currently not supported. Calls to unsupported precompiled contracts will revert. We plan to enable these precompiles in future hard forks.
+The `RIPEMD-160` (address `0x3`), `blake2f` (address `0x9`), and `point evaluation` (address `0x0a`) precompiles are currently not supported. Calls to unsupported precompiled contracts will revert. We plan to enable these precompiles in future hard forks.
 
 The `modexp` precompile is supported but only supports inputs of size less than or equal to 32 bytes (i.e. `u256`).
 
-The `ecPairing` precompile is supported, but the number of points(sets, pairs) is limited to 4, instead of 6.
+The `ecPairing` precompile is supported, but the number of points (sets, pairs) is limited to 4, instead of 6.
 
 The other EVM precompiles are all supported: `ecRecover`, `identity`, `ecAdd`, `ecMul`.
 
 ### Precompile Limits
 
-Because of a bounded size of the zkEVM circuits, there is an upper limit on the number of calls that can be made for some precompiles. These transactions will not revert, but simply be skipped by the sequencer if they cannot fit into the space of the circuit. Read more about the [Circuit Capacity Checker](/en/technology/sequencer/execution-node#circuit-capacity-checker). 
+Because of a bounded size of the zkEVM circuits, there is an upper limit on the number of calls that can be made for some precompiles. These transactions will not revert, but simply be skipped by the sequencer if they cannot fit into the space of the circuit. Read more about the [Circuit Capacity Checker](/en/technology/sequencer/execution-node#circuit-capacity-checker).
 
-| Precompile / Opcode | Limit | 
+| Precompile / Opcode | Limit |
 | ------------------- | ----- |
 | `keccak256`         | 3157  |
 | `ecRecover`         | 119   |
@@ -87,7 +87,7 @@ Related to this, we maintain two types of codehash for each contract bytecode: K
 
 ### CodeSize
 
-When verifying `EXTCODESIZE`, it is expensive to load the whole contract data into the zkEVM. Instead, we store the contract size in storage during contract creation. This way, we do not need to load the code — a storage proof is sufficient to verify this opcode.
+When verifying `EXTCODESIZE`, it is expensive to load the whole contract data into the zkEVM. Instead, we store the contract size in storage during contract creation. This way, we do not need to load the code - a storage proof is sufficient to verify this opcode.
 
 ## Block Time
 
@@ -97,15 +97,15 @@ To improve the throughput of the Scroll chain, we introduced a dynamic block tim
 
 Similarly to Ethereum, the Scroll sequencer aims to prioritize executable transactions based on their "tip" (priority fee). In most cases, transactions will be included in the next block in decreasing order of their tips.
 
-However, just like in Ethereum, this ordering is not guaranteed by the protocol, and some blocks might diverge from it. In particular, during periods of low mempool congestion, the sequencer will process transactions on a first-come-first-served basis, so some transactions might precede others with higher tip in the same block.
+However, just like in Ethereum, this ordering is not guaranteed by the protocol, and some blocks might diverge from it. In particular, during periods of low mempool congestion, the sequencer will process transactions on a first-come-first-served basis, so some transactions might precede others with a higher tip in the same block.
 
-## Reorgs and Finality 
+## Reorgs and Finality
 
-Starting from our [DarwinV2 upgrade](/technology/overview/scroll-upgrades#darwinv2-upgrade), the maximum reorg depth has been set to 17 blocks. Transaction ordering should be unchanged after this threshold, however the only absolute guarantee is for transactions to be finalized (proof submitted to L1).
+Starting from our [DarwinV2 upgrade](/technology/overview/scroll-upgrades#darwinv2-upgrade), the maximum reorg depth has been set to 17 blocks. Transaction ordering should be unchanged after this threshold; however, the only absolute guarantee is for transactions to be finalized (proof submitted to L1).
 
 ## Future EIPs
 
-We keep a close eye on all emerging EIPs adopted by Ethereum and adopt them when suitable. If you’re interested in more specifics, reach out in [our community forum](https://community.scroll.io) or on the [Scroll Discord](https://discord.gg/scroll).
+We keep a close eye on all emerging EIPs adopted by Ethereum and adopt them when suitable. If you're interested in more specifics, reach out in [our community forum](https://community.scroll.io) or on the [Scroll Discord](https://discord.gg/scroll).
 
 ## Transaction Fees
 

--- a/src/content/docs/en/developers/guides/estimating-gas-and-tx-fees.mdx
+++ b/src/content/docs/en/developers/guides/estimating-gas-and-tx-fees.mdx
@@ -4,7 +4,7 @@ date: Last Modified
 title: "Estimating Gas and Tx Fees"
 lang: "en"
 permalink: "developers/guides/estimating-gas-and-transaction-fees"
-excerpt: "Since Scroll is an L2 rollup, part of the transaction lifecycle is committing some data to L1 for security. To pay for this, all transaction incurs an additional fee called the L1 fee"
+excerpt: "Since Scroll is an L2 rollup, part of the transaction lifecycle is committing some data to L1 for security. To pay for this, all transactions incur an additional fee called the L1 fee"
 ---
 
 import Aside from "../../../../../components/Aside.astro"
@@ -17,7 +17,7 @@ import txFeesProjectStructure from "../../../../../assets/images/developers/txFe
 This page has not been updated and tested against the latest Scroll Sepolia release. Please use with caution.
 :::
 
-Since Scroll is an L2 rollup, part of the transaction lifecycle is committing some data to L1 for security. To pay for this, all transaction incurs an additional fee called the _L1 fee_.
+Since Scroll is an L2 rollup, part of the transaction lifecycle is committing some data to L1 for security. To pay for this, all transactions incur an additional fee called the _L1 fee_.
 
 In this guide, we will go over how to estimate the L1 fee on Scroll and calculate final transaction fee estimations through a hands-on code example you can find [here](https://github.com/scroll-tech/scroll-guides/tree/main/gas-estimation-demo).
 

--- a/src/content/docs/en/developers/index.mdx
+++ b/src/content/docs/en/developers/index.mdx
@@ -66,7 +66,7 @@ You can request testnet ETH via the official Scroll telegram faucet bot by sendi
 
 **Is there an alternative way to get testnet ETH?**
 
-Yes. Please refer to our list of [Unofficial Faucets](https://docs.scroll.io/en/user-guide/faucet/) on both Sepolia and Scroll Sepolia. Remember, you can either receive Scroll Sepolia ETH directly or trough the [Sepolia Testnet Bridge](https://sepolia.scroll.io/bridge).
+Yes. Please refer to our list of [Unofficial Faucets](https://docs.scroll.io/en/user-guide/faucet/) on both Sepolia and Scroll Sepolia. Remember, you can either receive Scroll Sepolia ETH directly or through the [Sepolia Testnet Bridge](https://sepolia.scroll.io/bridge).
 
 ## EVM Compatibility & Infrastructure
 
@@ -87,15 +87,15 @@ Use our [Dune dashboard](https://docs.scroll.io/en/developers/developer-ecosyste
 
 ## Node Questions
 
-**Where can i download Scroll node's snapshot?**
+**Where can I download a Scroll node snapshot?**
 
 Mainnet : https://scroll-geth-snapshot.s3.us-west-2.amazonaws.com/mpt/latest.tar
 
 Sepolia : https://scroll-sepolia-l2geth-snapshots.s3.us-west-2.amazonaws.com/mpt/latest.tar
 
-**Scroll snapshot size is too large, do you have pruned snapshot?**
+**Scroll snapshot size is too large. Do you have a pruned snapshot?**
 
-Unfortunately, pruned snapshots are not available for Scroll. You may consider changing the garbage collection mode from archive to full to reduce the size of the snapshot by changing flag from --gcmode archive to --gcmode full
+Unfortunately, pruned snapshots are not available for Scroll. You may consider changing the garbage collection mode from archive to full to reduce the size of the snapshot by changing the flag from `--gcmode archive` to `--gcmode full`.
 
 **Can I run my own node on Scroll?**
 
@@ -111,7 +111,7 @@ Please join the Scroll Discord server and ask on the `#developers` or `#develope
 
 To connect with the BD team please fill the [Scroll BD Intake form](https://tally.so/r/wM2aaE).
 
-**How to keep track of any changes in Scroll?**
+**How do I keep track of changes in Scroll?**
 
 You can follow our telegram announcement channel [here](https://t.me/scroll_tech_announcements).
 

--- a/src/content/docs/en/developers/l1-and-l2-bridging/erc1155-token-bridge.mdx
+++ b/src/content/docs/en/developers/l1-and-l2-bridging/erc1155-token-bridge.mdx
@@ -87,7 +87,7 @@ The `L2ERC1155Gateway` contract is used to send tokens from L2 to L1. Before bri
 
 <Aside type="caution" title="">
   **Make sure the transaction won't revert on L1** while sending from L2. There is no way to recover tokens bridged if
-  you're transaction reverts on L1. All assets are burnt on L2 when the transaction is sent, and it's impossible to mint
+  your transaction reverts on L1. All assets are burnt on L2 when the transaction is sent, and it's impossible to mint
   them again.
 </Aside>
 

--- a/src/content/docs/en/developers/transaction-fees-on-scroll.mdx
+++ b/src/content/docs/en/developers/transaction-fees-on-scroll.mdx
@@ -5,7 +5,7 @@ title: "Transaction Fees on Scroll"
 lang: "en"
 permalink: "developers/transaction-fees-on-scroll"
 whatsnext: { "Developer Ecosystem": "/en/developers/developer-ecosystem/" }
-excerpt: "Understand how L1 and L2 transaction fees work on Scroll "
+excerpt: "Understand how L1 and L2 transaction fees work on Scroll"
 ---
 
 import Aside from "../../../../components/Aside.astro"
@@ -56,7 +56,7 @@ In other words, the execution fee is calculated precisely like pre-[EIP1559](htt
 
 Every transaction's calldata must be committed to Ethereum, which incurs an additional transaction fee, referred to as the "L1 Fee". Without doing this, Scroll couldn't be reconstructed from only L1 data.
 
-Transactions aren't committed 1-by-1 -- they are collected in batches of blocks (and blocks of transactions). The cost of an individual transaction is computed based on the zeros and non-zero bytes in its payload.
+Transactions aren't committed one by one — they are collected in batches of blocks (and blocks of transactions). The cost of an individual transaction is computed based on the zeros and non-zero bytes in its payload.
 
 ### Estimating the L1 Data Fee
 


### PR DESCRIPTION
Closes #550

Improves grammar and terminology consistency across the Building on Scroll documentation section:

**building-on-scroll.mdx:**
- Hyphenated "zero-knowledge" consistently (was "zero knowledge")
- Removed incorrect article ("the Scroll" → "Scroll")
- Removed unnecessary comma in heading
- Standardized L1/L2 terminology (was mixing "Layer 1"/"Layer 2" with "L1"/"L2")

**index.mdx:**
- Fixed typo: "trough" → "through"
- Fixed capitalization: "can i" → "can I"
- Improved question phrasing for FAQ consistency
- Added inline code formatting for CLI flags

**ethereum-and-scroll-differences.mdx:**
- Fixed footnote typo: "willadpot" → "willadopt"
- Added missing comma in precompiles list
- Added missing space before parenthetical
- Fixed semicolon usage before "however"
- Removed trailing whitespace

**developer-ecosystem.mdx:**
- Fixed typo: "pereference" → "preference"
- Fixed typo: "accesibility" → "accessibility"
- Fixed typo: "Compund" → "Compound" (2 occurrences)

**estimating-gas-and-tx-fees.mdx:**
- Fixed subject-verb agreement: "all transaction incurs" → "all transactions incur"

**transaction-fees-on-scroll.mdx:**
- Removed trailing space in frontmatter
- Improved phrasing: "1-by-1" → "one by one"

**erc1155-token-bridge.mdx:**
- Fixed contraction: "you're transaction" → "your transaction"