### PR TITLE
docs: add TrailOfBits audit link for Curie upgrade

### DIFF
--- a/src/content/docs/en/technology/overview/scroll-upgrades/curie-upgrade.mdx
+++ b/src/content/docs/en/technology/overview/scroll-upgrades/curie-upgrade.mdx
@@ -52,7 +52,7 @@ The new version of zkevm circuits is `v0.11.4`. See [here](https://github.com/sc
 
 #### Audits
 
-- TrailofBits: coming soon!
+- [TrailofBits](https://github.com/trailofbits/publications/blob/master/reviews/2024-06-scroll-zstd-compression-securityreview.pdf)
 - [Zellic](https://github.com/Zellic/publications/blob/master/Scroll%20zkEVM%20-%20Zellic%20Audit%20Report.pdf)
 
 ### Compatibility

--- a/src/content/docs/es/technology/overview/scroll-upgrades/curie-upgrade.mdx
+++ b/src/content/docs/es/technology/overview/scroll-upgrades/curie-upgrade.mdx
@@ -51,7 +51,7 @@ Nueva versión de circuitos zkevm: `v0.11.4`. Ver [aquí](https://github.com/scr
 
 #### Auditorías
 
-- TrailofBits: ¡Próximamente!
+- [TrailofBits](https://github.com/trailofbits/publications/blob/master/reviews/2024-06-scroll-zstd-compression-securityreview.pdf)
 - [Zellic](https://github.com/Zellic/publications/blob/master/Scroll%20zkEVM%20-%20Zellic%20Audit%20Report.pdf)
 
 ### Compatibilidad

--- a/src/content/docs/tr/technology/overview/scroll-upgrades/curie-upgrade.mdx
+++ b/src/content/docs/tr/technology/overview/scroll-upgrades/curie-upgrade.mdx
@@ -51,7 +51,7 @@ Yeni sürüm: `v0.11.4`. [Yayın günlüğü burada](https://github.com/scroll-t
 
 #### Denetimler
 
-- TrailofBits: yakında!
+- [TrailofBits](https://github.com/trailofbits/publications/blob/master/reviews/2024-06-scroll-zstd-compression-securityreview.pdf)
 - [Zellic](https://github.com/Zellic/publications/blob/master/Scroll%20zkEVM%20-%20Zellic%20Audit%20Report.pdf)
 
 ### Uyumluluk

--- a/src/content/docs/zh/technology/overview/scroll-upgrades/curie-upgrade.mdx
+++ b/src/content/docs/zh/technology/overview/scroll-upgrades/curie-upgrade.mdx
@@ -51,7 +51,7 @@ permalink: "technology/overview/scroll-upgrades/curie-upgrade"
 
 #### 审计
 
-- TrailofBits：即将上线！
+- [TrailofBits](https://github.com/trailofbits/publications/blob/master/reviews/2024-06-scroll-zstd-compression-securityreview.pdf)
 - [Zellic](https://github.com/Zellic/publications/blob/master/Scroll%20zkEVM%20-%20Zellic%20Audit%20Report.pdf)
 
 ### 兼容性


### PR DESCRIPTION
## Summary

Replace the "coming soon" placeholder for the TrailOfBits audit in the Curie upgrade page with the actual [zstd compression security review](https://github.com/trailofbits/publications/blob/master/reviews/2024-06-scroll-zstd-compression-securityreview.pdf) link.

Updated across all language versions (en, es, tr, zh).

Closes #417