### PR TITLE
docs: update Transaction Type section to include EIP-2930 and EIP-1559

### DIFF
--- a/src/content/docs/en/technology/chain/transactions.mdx
+++ b/src/content/docs/en/technology/chain/transactions.mdx
@@ -14,13 +14,13 @@ A transaction is a cryptographically signed message that initiates a state trans
 
 ## Transaction Type
 
-Currently, Scroll supports three types of transactions.
+Currently, Scroll supports five types of transactions.
 
 - Pre-EIP-155 Transaction: This is to support the [Singleton Factory](https://eips.ethereum.org/EIPS/eip-2470) contract.
 - Legacy Transaction (refer to [EIP-155](https://eips.ethereum.org/EIPS/eip-155))
+- [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) Access List Transaction (Type: `0x01`): Supported since the [Curie upgrade](/en/technology/overview/scroll-upgrades/curie-upgrade).
+- [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) Dynamic Fee Transaction (Type: `0x02`): Supported since the [Curie upgrade](/en/technology/overview/scroll-upgrades/curie-upgrade). Scroll uses a modified version of the EIP-1559 pricing model.
 - `L1MessageTx` Typed Transaction (Type: `0x7E`): This is a new [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) transaction introduced in Scroll as described below. This transaction type is for transactions initiated on L1.
-
-Note that [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) and [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) transaction types are not supported in Scroll currently. Scroll will bring back these two transaction types in the future.
 
 ### L1 Message Transaction
 

--- a/src/content/docs/es/technology/chain/transactions.mdx
+++ b/src/content/docs/es/technology/chain/transactions.mdx
@@ -14,13 +14,13 @@ Una transacción es un mensaje firmado criptográficamente que inicia una transi
 
 ## Tipo de Transacción
 
-Actualmente, Scroll admite tres tipos de transacciones.
+Actualmente, Scroll admite cinco tipos de transacciones.
 
 - Transacción Pre-EIP-155: Soporta el contrato [Singleton Factory](https://eips.ethereum.org/EIPS/eip-2470).
 - Transacción Legacy (consulte [EIP-155](https://eips.ethereum.org/EIPS/eip-155))
+- [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) Transacción con Lista de Acceso (Tipo: `0x01`): Soportado desde la [actualización Curie](/es/technology/overview/scroll-upgrades/curie-upgrade).
+- [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) Transacción con Tarifa Dinámica (Tipo: `0x02`): Soportado desde la [actualización Curie](/es/technology/overview/scroll-upgrades/curie-upgrade). Scroll utiliza una versión modificada del modelo de precios EIP-1559.
 - Transacción tipo `L1MessageTx` (Tipo: `0x7E`): Se trata de una nueva transacción [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) introducida en Scroll como se describe a continuación. Este tipo de transacción es para transacciones iniciadas en L1.
-
-Ten en cuenta que los tipos de transacción [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) y [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) no están soportados actualmente en Scroll. Scroll incorporará estos dos tipos de transacción en el futuro.
 
 ### Transacción de Mensajes en L1
 

--- a/src/content/docs/tr/technology/chain/transactions.mdx
+++ b/src/content/docs/tr/technology/chain/transactions.mdx
@@ -14,13 +14,13 @@ import TransactionBatching from "../_images/batching.png"
 
 ## İşlem tipi
 
-Şu anda Scroll üç tür işlemi desteklemektedir.
+Şu anda Scroll beş tür işlemi desteklemektedir.
 
 - EIP-155 Öncesi İşlem: Bu, [Singleton Factory](https://eips.ethereum.org/EIPS/eip-2470) sözleşmesini desteklemek içindir.
 - Eski Tip İşlem (bkz. [EIP-155](https://eips.ethereum.org/EIPS/eip-155))
+- [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) Erişim Listesi İşlemi (Tip: `0x01`): [Curie yükseltmesinden](/tr/technology/overview/scroll-upgrades/curie-upgrade) itibaren desteklenmektedir.
+- [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) Dinamik Ücret İşlemi (Tip: `0x02`): [Curie yükseltmesinden](/tr/technology/overview/scroll-upgrades/curie-upgrade) itibaren desteklenmektedir. Scroll, EIP-1559 fiyatlandırma modelinin değiştirilmiş bir sürümünü kullanır.
 - `L1MessageTx` Tipi Belirli İşlem (Tip: `0x7E`): Bu, aşağıda açıklandığı gibi Scroll'da tanıtılan yeni bir [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) işlemidir. Bu işlem tipi L1'de başlatılan işlemler içindir.
-
-Unutmayın ki [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) ve [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) işlem tipleri şu anda Scroll'da desteklenmemektedir. Scroll gelecekte bu iki işlem türünü geri getirecektir.
 
 ### L1 Mesaj İşlemi
 

--- a/src/content/docs/zh/technology/chain/transactions.mdx
+++ b/src/content/docs/zh/technology/chain/transactions.mdx
@@ -14,13 +14,13 @@ import TransactionBatching from "../_images/batching.png"
 
 ## 交易类型
 
-目前，Scroll 支持三种类型的交易。
+目前，Scroll 支持五种类型的交易。
 
 - Pre-EIP-155 交易: 以支持 [Singleton Factory](https://eips.ethereum.org/EIPS/eip-2470) 合约。
 - Legacy 交易 (参考 [EIP-155](https://eips.ethereum.org/EIPS/eip-155))
+- [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) 访问列表交易 (类型: `0x01`): 自 [Curie 升级](/zh/technology/overview/scroll-upgrades/curie-upgrade)起支持。
+- [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) 动态费用交易 (类型: `0x02`): 自 [Curie 升级](/zh/technology/overview/scroll-upgrades/curie-upgrade)起支持。Scroll 使用修改版的 EIP-1559 定价模型。
 - `L1MessageTx` 类型交易 (类型: `0x7E`): 这是 Scroll 引入的一种新的 [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) 交易，如下所述。此交易类型适用于在 L1 上发起的交易。
-
-请注意，Scroll 当前不支持 [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) 和 [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) 交易类型。Scroll 未来将会引入这两种交易类型。
 
 ### L1 Message 交易
 


### PR DESCRIPTION
## Summary

Since the [Curie upgrade](https://docs.scroll.io/en/technology/overview/scroll-upgrades/curie-upgrade/), Scroll supports [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) (Access List) and [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) (Dynamic Fee) transaction types.

### Changes

- Updated "three types" → "five types" of supported transactions
- Added EIP-2930 Access List Transaction (Type `0x01`) entry with link to Curie upgrade
- Added EIP-1559 Dynamic Fee Transaction (Type `0x02`) entry with link to Curie upgrade
- Removed outdated "not supported" note
- Updated across all language versions (en, es, tr, zh)

Reference: [Curie upgrade blog post](https://scroll.io/blog/compressing-the-gas-scrolls-curie-upgrade)

Closes #407