### PR TITLE
Update Scroll snapshot link

### DIFF
--- a/src/content/docs/en/developers/guides/running-a-scroll-node.mdx
+++ b/src/content/docs/en/developers/guides/running-a-scroll-node.mdx
@@ -73,7 +73,7 @@ Download the latest l2geth :
 
 ### Download the Snapshot
 
-SNAPSHOT_URL =  https://scroll-geth-snapshot.s3.us-west-2.amazonaws.com/mpt/latest.tar
+SNAPSHOT_URL =  https://snapshot.scroll.io/mpt/latest.tar
 
 1. Download the snapshot
 ```bash

--- a/src/content/docs/en/developers/index.mdx
+++ b/src/content/docs/en/developers/index.mdx
@@ -85,7 +85,7 @@ Use our [Dune dashboard](https://docs.scroll.io/en/developers/developer-ecosyste
 
 **Where can i download Scroll node's snapshot?**
 
-Mainnet : https://scroll-geth-snapshot.s3.us-west-2.amazonaws.com/mpt/latest.tar
+Mainnet : https://snapshot.scroll.io/mpt/latest.tar
 
 Sepolia : https://scroll-sepolia-l2geth-snapshots.s3.us-west-2.amazonaws.com/mpt/latest.tar
 


### PR DESCRIPTION
## Summary
- replace the mainnet MPT snapshot link with the new snapshot.scroll.io URL

## Tests
- Not run (docs-only URL update)