### PR TITLE
Update Sepolia snapshot link

### DIFF
--- a/src/content/docs/en/developers/index.mdx
+++ b/src/content/docs/en/developers/index.mdx
@@ -87,7 +87,7 @@ Use our [Dune dashboard](https://docs.scroll.io/en/developers/developer-ecosyste
 
 Mainnet : https://snapshot.scroll.io/mpt/latest.tar
 
-Sepolia : https://scroll-sepolia-l2geth-snapshots.s3.us-west-2.amazonaws.com/mpt/latest.tar
+Sepolia : https://snapshot.scroll.io/sepolia/mpt/latest.tar
 
 **Scroll snapshot size is too large, do you have pruned snapshot?**
 


### PR DESCRIPTION
## Summary
- replace the Sepolia MPT snapshot link with the new snapshot.scroll.io URL

## Tests
- Not run (docs-only URL update)