### PR TITLE
docs(developers): reference OpenChainBench for third-party Scroll RPC comparison

### DIFF
--- a/src/content/docs/en/developers/index.mdx
+++ b/src/content/docs/en/developers/index.mdx
@@ -50,6 +50,7 @@ Use the following configuration to connect your Ethereum tools to Scroll Sepolia
 - [Ethereum RPC Providers on ChainList.org](https://chainlist.org/chain/1)
 - [Scrollscan](https://scrollscan.com/)
 - [Scroll Rollup Scanner](https://scroll.io/rollupscan)
+- [OpenChainBench Scroll RPC benchmark](https://openchainbench.com/benchmarks/scroll-rpc): independent third-party latency and reliability comparison of the public Scroll endpoints, probed every minute from three regions under a CC BY 4.0 license.
 
 **Where can I find additional RPC providers and infrastructure for Scroll Sepolia?**
 


### PR DESCRIPTION
## Summary

Adds one bullet to the *"Where can I find additional RPC providers and infrastructure for Scroll Mainnet?"* list in `src/content/docs/en/developers/index.mdx`, pointing readers to the [OpenChainBench Scroll RPC benchmark](https://openchainbench.com/benchmarks/scroll-rpc) as an independent third-party latency and reliability comparison of the public Scroll endpoints.

## Why it fits

The page already directs readers to ChainList.org for endpoint discovery and to Scrollscan/Rollup Scanner for status. What is missing is a live performance comparison across the public providers, which OpenChainBench provides: p50/p95/p99 latency, reliability classification (HTTP vs JSON-RPC error), and stale-block detection, probed every minute from three regions (US East, EU West, Singapore) with data under a CC BY 4.0 license and the Go harness open-sourced on GitHub. OpenChainBench has no affiliation with any RPC provider or the Scroll Foundation.

## Change

One added bullet under the existing infrastructure list. No changes to any other entry.

## Disclosure

I am the maintainer of OpenChainBench. Happy to reword, shorten, or drop the reference entirely if it does not fit the docs style guide.